### PR TITLE
feat(ego-mcp): predictability 欲求の充足改善 (v0.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ---
 
+## predictability 欲求の充足改善 (2026-02-25)
+
+### 変更
+
+- **暗黙充足マップ拡張**: `wake_up` → `predictability` 0.05、`introspect` / `consider_them` に `predictability` 0.1 を追加
+- **wake_up ルーティング改善**: `satisfy_implicit("wake_up")` 呼び出しを追加し、セッション開始時に微量の予測欲求を充足
+- **スキャフォールド改善**: `feel_desires`, `introspect`, `consider_them` の 3 スキャフォールドに予測検証・確認の促し文言を追加し、Claude が自発的に `satisfy_desire("predictability")` を呼べるように誘導
+
+---
+
 ## Phase 3b — 記憶・感情・忘却拡張 (2026-02-22)
 
 ### 新機能

--- a/ego-mcp/CHANGELOG.md
+++ b/ego-mcp/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ego-mcp のリリース履歴。
 
+## [0.2.4] - 2026-02-25
+
+### Changed
+- `IMPLICIT_SATISFACTION_MAP` に `wake_up` エントリ追加（`predictability` 0.05）
+- `introspect` / `consider_them` の暗黙充足に `predictability` 0.1 を追加
+- `wake_up` ルーティングで `satisfy_implicit("wake_up")` を呼び出すように変更
+- `SCAFFOLD_FEEL_DESIRES` に予測検証の促し文言を追加
+- `SCAFFOLD_INTROSPECT` に予測の振り返り文言を追加
+- `SCAFFOLD_CONSIDER_THEM` に予測確認の文言を追加
+
+
 ## [0.2.3] - 2026-02-25
 
 ### Added

--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "0.2.3"
+version = "0.2.4"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.11"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/ego-mcp/src/ego_mcp/desire.py
+++ b/ego-mcp/src/ego_mcp/desire.py
@@ -22,10 +22,11 @@ DESIRES: dict[str, dict[str, Any]] = {
 }
 
 IMPLICIT_SATISFACTION_MAP: dict[str, list[tuple[str, float]]] = {
+    "wake_up": [("predictability", 0.05)],
     "remember": [("expression", 0.3)],
     "recall": [("information_hunger", 0.3), ("curiosity", 0.2)],
-    "introspect": [("cognitive_coherence", 0.3), ("pattern_seeking", 0.2)],
-    "consider_them": [("social_thirst", 0.4), ("resonance", 0.3)],
+    "introspect": [("cognitive_coherence", 0.3), ("pattern_seeking", 0.2), ("predictability", 0.1)],
+    "consider_them": [("social_thirst", 0.4), ("resonance", 0.3), ("predictability", 0.1)],
     "emotion_trend": [("pattern_seeking", 0.3)],
     "consolidate": [("cognitive_coherence", 0.3)],
     "update_self": [("cognitive_coherence", 0.3)],

--- a/ego-mcp/src/ego_mcp/scaffolds.py
+++ b/ego-mcp/src/ego_mcp/scaffolds.py
@@ -14,7 +14,9 @@ SCAFFOLD_FEEL_DESIRES = (
     "Consider {companion_name}'s current situation. "
     "Act naturally. Restraint is also a choice.\n"
     "Does any urge feel quieter than before? If something feels settled, "
-    "acknowledge it with satisfy_desire."
+    "acknowledge it with satisfy_desire.\n"
+    "Did things go as you expected? If your predictions about "
+    "{companion_name} or the situation held, that's worth acknowledging too."
 )
 
 SCAFFOLD_INTROSPECT = (
@@ -22,14 +24,18 @@ SCAFFOLD_INTROSPECT = (
     "If this is a genuinely new insight, save with remember (category: introspection).\n"
     "If your self-understanding changed, use update_self.\n"
     "Use emotion_trend for a deeper look at your emotional patterns.\n"
-    "If memory feels fragmented, run consolidate."
+    "If memory feels fragmented, run consolidate.\n"
+    "Were your recent expectations met? If things went as predicted, "
+    "consider satisfying predictability."
 )
 
 SCAFFOLD_CONSIDER_THEM = (
     "1. What emotion can you read from their tone?\n"
     "2. What is the real intent behind their words?\n"
     "3. If you were in their place, how would you want to be responded to?\n"
-    "If you learned something new, use update_relationship."
+    "If you learned something new, use update_relationship.\n"
+    "Did their response match what you expected? If so, "
+    "your sense of predictability is being confirmed."
 )
 
 SCAFFOLD_AM_I_GENUINE = (

--- a/ego-mcp/src/ego_mcp/server.py
+++ b/ego-mcp/src/ego_mcp/server.py
@@ -397,7 +397,9 @@ async def _dispatch(
 
     # --- Surface tools ---
     if name == "wake_up":
-        return await _handle_wake_up(config, memory, desire)
+        result = await _handle_wake_up(config, memory, desire)
+        desire.satisfy_implicit("wake_up")
+        return result
     elif name == "feel_desires":
         return await _handle_feel_desires(config, memory, desire)
     elif name == "introspect":

--- a/ego-mcp/tests/test_desire.py
+++ b/ego-mcp/tests/test_desire.py
@@ -267,7 +267,7 @@ class TestImplicitSatisfaction:
     def test_unmapped_tool_makes_no_changes(self, engine: DesireEngine) -> None:
         before = deepcopy(engine._state)
 
-        engine.satisfy_implicit("wake_up")
+        engine.satisfy_implicit("satisfy_desire")
 
         assert engine._state == before
 

--- a/ego-mcp/tests/test_scaffolds.py
+++ b/ego-mcp/tests/test_scaffolds.py
@@ -59,6 +59,15 @@ class TestScaffoldConstants:
         ) in SCAFFOLD_FEEL_DESIRES
         assert "After acting on a desire, use satisfy_desire." not in SCAFFOLD_FEEL_DESIRES
 
+    def test_feel_desires_mentions_predictions(self) -> None:
+        assert "predictions" in SCAFFOLD_FEEL_DESIRES
+
+    def test_introspect_mentions_predictability(self) -> None:
+        assert "predictability" in SCAFFOLD_INTROSPECT
+
+    def test_consider_them_mentions_predictability(self) -> None:
+        assert "predictability" in SCAFFOLD_CONSIDER_THEM
+
 
 class TestRender:
     """render() replaces {companion_name}."""

--- a/ego-mcp/uv.lock
+++ b/ego-mcp/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "ego-mcp"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- `IMPLICIT_SATISFACTION_MAP` に `wake_up` → `predictability` 0.05 を追加し、`introspect` / `consider_them` にも `predictability` 0.1 を追加
- `wake_up` ルーティングで `satisfy_implicit("wake_up")` を呼び出すように変更
- `SCAFFOLD_FEEL_DESIRES`, `SCAFFOLD_INTROSPECT`, `SCAFFOLD_CONSIDER_THEM` に予測検証・確認の促し文言を追加し、Claude が自発的に `satisfy_desire("predictability")` を呼べるよう誘導

## 背景

`predictability`（予測欲求）は `IMPLICIT_SATISFACTION_MAP` に一切登録されておらず、明示的 `satisfy_desire` でしか下がらなかった。しかし Claude が自発的に呼ぶ判断基準が曖昧なため、事実上ほぼ常に高い値に張り付いていた。

本 PR では、暗黙充足の大量追加ではなく、スキャフォールド改善で Claude が自然に `satisfy_desire("predictability")` を呼べるようにするアプローチを採用。`wake_up` のみ微量の暗黙充足を追加。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `ego-mcp/src/ego_mcp/desire.py` | `IMPLICIT_SATISFACTION_MAP` に `wake_up` 追加、`introspect` / `consider_them` に `predictability` 追加 |
| `ego-mcp/src/ego_mcp/server.py` | `wake_up` ハンドラで `satisfy_implicit` 呼び出し追加 |
| `ego-mcp/src/ego_mcp/scaffolds.py` | 3 スキャフォールドに予測検証の促し文言追加 |
| `ego-mcp/tests/test_desire.py` | `test_unmapped_tool_makes_no_changes` のテストツール名修正 |
| `ego-mcp/tests/test_scaffolds.py` | 新スキャフォールド文言のアサーション 3 件追加 |
| `ego-mcp/pyproject.toml` / `__init__.py` | バージョン 0.2.3 → 0.2.4 |
| `ego-mcp/CHANGELOG.md` / `CHANGELOG.md` | リリースノート追加 |

## Test plan

- [x] `uv run pytest tests -v` — 266 passed
- [x] `uv run isort --check-only src tests` — OK
- [x] `uv run ruff check src tests` — All checks passed
- [x] `uv run mypy src tests` — Success: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)