### PR TITLE
feat: ダッシュボードのテレメトリ表示・UX を包括的に改善

### DIFF
--- a/dashboard/frontend/src/App.test.tsx
+++ b/dashboard/frontend/src/App.test.tsx
@@ -38,12 +38,12 @@ vi.mock('./api', () => ({
 }))
 
 describe('App', () => {
-  it('shows now tab summary cards with 24h tool calls', async () => {
+  it('shows now tab summary cards with local-day tool calls', async () => {
     render(<App />)
+    expect(await screen.findByText('tool calls (today)')).toBeInTheDocument()
     expect(
-      await screen.findByText('tool calls (24h total)'),
+      await screen.findByText('tool calls (yesterday)'),
     ).toBeInTheDocument()
-    expect(await screen.findByText('3')).toBeInTheDocument()
     expect(await screen.findByText('curious')).toBeInTheDocument()
   })
 

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -78,7 +78,7 @@ const App = () => {
         </TabsContent>
 
         <TabsContent value="logs">
-          <LogsTab range={range} />
+          <LogsTab range={range} isActive={activeTab === 'logs'} />
         </TabsContent>
       </Tabs>
     </main>

--- a/dashboard/frontend/src/components/history/desire-history-chart.tsx
+++ b/dashboard/frontend/src/components/history/desire-history-chart.tsx
@@ -35,7 +35,13 @@ export const DesireHistoryChart = ({
             <XAxis dataKey="ts" hide />
             <YAxis domain={[0, 1]} />
             <ChartTooltip
-              content={<ChartTooltipContent labelFormatter={formatTs} />}
+              content={
+                <ChartTooltipContent
+                  labelFormatter={formatTs}
+                  showAllSeries
+                  missingValueLabel="-"
+                />
+              }
             />
             <ChartLegend content={<ChartLegendContent />} />
             {DESIRE_METRIC_KEYS.map((key) => (

--- a/dashboard/frontend/src/components/history/tool-usage-chart.tsx
+++ b/dashboard/frontend/src/components/history/tool-usage-chart.tsx
@@ -49,7 +49,7 @@ export const ToolUsageChart = ({
     toolSeriesKeys.map((key, i) => [
       key,
       {
-        label: key,
+        label: key.replaceAll('_', ' '),
         color: TOOL_CHART_COLORS[i % TOOL_CHART_COLORS.length],
       },
     ]),
@@ -101,7 +101,9 @@ export const ToolUsageChart = ({
             <XAxis dataKey="ts" hide />
             <YAxis />
             <ChartTooltip
-              content={<ChartTooltipContent labelFormatter={formatTs} />}
+              content={
+                <ChartTooltipContent labelFormatter={formatTs} showAllSeries />
+              }
             />
             <ChartLegend content={<ChartLegendContent />} />
             {toolSeriesKeys.map((toolName) => (

--- a/dashboard/frontend/src/components/history/valence-arousal-chart.tsx
+++ b/dashboard/frontend/src/components/history/valence-arousal-chart.tsx
@@ -61,7 +61,13 @@ export const ValenceArousalChart = ({
             <XAxis dataKey="ts" hide />
             <YAxis domain={[-1, 1]} />
             <ChartTooltip
-              content={<ChartTooltipContent labelFormatter={formatTs} />}
+              content={
+                <ChartTooltipContent
+                  labelFormatter={formatTs}
+                  showAllSeries
+                  missingValueLabel="-"
+                />
+              }
             />
             <ChartLegend content={<ChartLegendContent />} />
             <Line

--- a/dashboard/frontend/src/components/now/activity-feed.tsx
+++ b/dashboard/frontend/src/components/now/activity-feed.tsx
@@ -34,7 +34,7 @@ export const ActivityFeed = ({ logLines }: ActivityFeedProps) => {
             {logLines.map((item, i) => (
               <div
                 key={`${item.ts}-${i}`}
-                className="flex items-center gap-2 text-xs"
+                className="flex items-start gap-2 text-xs"
               >
                 <span className="text-muted-foreground shrink-0 font-mono">
                   {formatTs(item.ts)}
@@ -50,6 +50,21 @@ export const ActivityFeed = ({ logLines }: ActivityFeedProps) => {
                 >
                   {item.ok ? 'ok' : 'error'}
                 </Badge>
+                {item.level && !item.tool_name && (
+                  <Badge variant="outline" className="text-[10px]">
+                    {item.level}
+                  </Badge>
+                )}
+                <div className="min-w-0 flex-1">
+                  {item.message && (
+                    <p className="truncate text-xs leading-4">{item.message}</p>
+                  )}
+                  {item.logger && (
+                    <p className="text-muted-foreground truncate text-[10px] leading-4">
+                      {item.logger}
+                    </p>
+                  )}
+                </div>
               </div>
             ))}
             <div ref={bottomRef} />

--- a/dashboard/frontend/src/components/now/desire-radar.tsx
+++ b/dashboard/frontend/src/components/now/desire-radar.tsx
@@ -1,4 +1,10 @@
-import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from 'recharts'
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+} from 'recharts'
 
 import {
   ChartContainer,
@@ -40,6 +46,7 @@ export const DesireRadar = ({ current }: DesireRadarProps) => {
               dataKey="name"
               tick={{ fontSize: 10, fill: 'var(--color-muted-foreground)' }}
             />
+            <PolarRadiusAxis domain={[0, 1]} tick={false} axisLine={false} />
             <PolarGrid stroke="var(--color-border)" />
             <Radar
               dataKey="value"

--- a/dashboard/frontend/src/components/now/session-summary.tsx
+++ b/dashboard/frontend/src/components/now/session-summary.tsx
@@ -1,54 +1,118 @@
+import { useEffect, useState } from 'react'
+
+import { fetchUsage } from '@/api'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { CurrentResponse } from '@/types'
+import type { DateRange, UsagePoint } from '@/types'
 
 type SessionSummaryProps = {
   current: CurrentResponse | null
 }
 
-export const SessionSummary = ({ current }: SessionSummaryProps) => (
-  <div className="grid gap-4 sm:grid-cols-3">
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-muted-foreground text-xs font-medium">
-          tool calls (24h total)
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-3xl font-bold">
-          {current?.window_24h?.tool_calls ?? 0}
-        </p>
-      </CardContent>
-    </Card>
+const sumToolCalls = (rows: UsagePoint[]) =>
+  rows.reduce((sum, row) => {
+    const rowTotal = Object.entries(row).reduce((rowSum, [key, value]) => {
+      if (key === 'ts' || typeof value !== 'number') return rowSum
+      return rowSum + value
+    }, 0)
+    return sum + rowTotal
+  }, 0)
 
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-muted-foreground text-xs font-medium">
-          error rate (24h)
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-3xl font-bold">
-          {(((current?.window_24h?.error_rate ?? 0) as number) * 100).toFixed(
-            1,
-          )}
-          %
-        </p>
-      </CardContent>
-    </Card>
+const localDayRanges = (): { today: DateRange; yesterday: DateRange } => {
+  const now = new Date()
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  )
+  const startOfYesterday = new Date(startOfToday)
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1)
+  const endOfYesterday = new Date(startOfToday.getTime() - 1)
 
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-muted-foreground text-xs font-medium">
-          latest latency
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-3xl font-bold">
-          {current?.latest?.duration_ms != null
-            ? `${current.latest.duration_ms}ms`
-            : 'n/a'}
-        </p>
-      </CardContent>
-    </Card>
-  </div>
-)
+  return {
+    today: {
+      from: startOfToday.toISOString(),
+      to: now.toISOString(),
+    },
+    yesterday: {
+      from: startOfYesterday.toISOString(),
+      to: endOfYesterday.toISOString(),
+    },
+  }
+}
+
+export const SessionSummary = ({ current }: SessionSummaryProps) => {
+  const [todayToolCalls, setTodayToolCalls] = useState(0)
+  const [yesterdayToolCalls, setYesterdayToolCalls] = useState(0)
+  const { clientTimeZone } = useTimestampFormatter()
+
+  useEffect(() => {
+    let disposed = false
+
+    const loadToolCallTotals = async () => {
+      const { today, yesterday } = localDayRanges()
+      const [todayRows, yesterdayRows] = await Promise.all([
+        fetchUsage(today, '15m'),
+        fetchUsage(yesterday, '15m'),
+      ])
+      if (disposed) return
+      setTodayToolCalls(sumToolCalls(todayRows))
+      setYesterdayToolCalls(sumToolCalls(yesterdayRows))
+    }
+
+    void loadToolCallTotals()
+    const timer = setInterval(loadToolCallTotals, 60_000)
+
+    return () => {
+      disposed = true
+      clearInterval(timer)
+    }
+  }, [])
+
+  return (
+    <div className="space-y-2">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium">
+              tool calls (today)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{todayToolCalls}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium">
+              tool calls (yesterday)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">{yesterdayToolCalls}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium">
+              latest latency
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold">
+              {current?.latest?.duration_ms != null
+                ? `${current.latest.duration_ms}ms`
+                : 'n/a'}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Timezone: {clientTimeZone}
+      </p>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/now/status-indicator.tsx
+++ b/dashboard/frontend/src/components/now/status-indicator.tsx
@@ -11,8 +11,8 @@ const getStatus = (current: CurrentResponse | null): StatusLevel => {
   const ts = current?.latest?.ts
   if (!ts) return 'no_data'
   const age = Date.now() - new Date(ts).getTime()
-  if (age < 30_000) return 'active'
-  if (age < 300_000) return 'idle'
+  if (age <= 15 * 60_000) return 'active'
+  if (age <= 60 * 60_000) return 'idle'
   return 'no_data'
 }
 

--- a/dashboard/frontend/src/components/ui/scroll-area.tsx
+++ b/dashboard/frontend/src/components/ui/scroll-area.tsx
@@ -6,8 +6,13 @@ import { cn } from '@/lib/utils'
 function ScrollArea({
   className,
   children,
+  viewportRef,
+  onViewportScroll,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>
+  onViewportScroll?: React.UIEventHandler<HTMLDivElement>
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -15,8 +20,10 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        onScroll={onViewportScroll}
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/dashboard/frontend/src/hooks/use-log-data.ts
+++ b/dashboard/frontend/src/hooks/use-log-data.ts
@@ -4,7 +4,7 @@ import { fetchLogs } from '@/api'
 import type { DateRange, LogPoint } from '@/types'
 
 export const useLogData = (
-  activeTab: string,
+  enabled: boolean,
   range: DateRange,
   logLevel: string,
   loggerFilter: string,
@@ -12,7 +12,7 @@ export const useLogData = (
   const [logs, setLogs] = useState<LogPoint[]>([])
 
   useEffect(() => {
-    if (activeTab !== 'logs') return
+    if (!enabled) return
 
     let disposed = false
     const loadLogs = async () => {
@@ -27,7 +27,7 @@ export const useLogData = (
       disposed = true
       clearInterval(timer)
     }
-  }, [activeTab, range, logLevel, loggerFilter])
+  }, [enabled, range, logLevel, loggerFilter])
 
   return logs
 }

--- a/dashboard/src/ego_dashboard/store.py
+++ b/dashboard/src/ego_dashboard/store.py
@@ -57,10 +57,13 @@ class TelemetryStore:
 
     def tool_usage(self, start: datetime, end: datetime, bucket: str) -> list[dict[str, object]]:
         events = self._filtered(start, end)
+        tool_names = sorted({ev.tool_name for ev in events})
         rows: list[dict[str, object]] = []
         for at, grouped in self._bucket_events(events, start, end, bucket):
             counts: dict[str, int] = Counter(ev.tool_name for ev in grouped)
-            row: dict[str, object] = {"ts": at.isoformat(), **counts}
+            row: dict[str, object] = {"ts": at.isoformat()}
+            for tool_name in tool_names:
+                row[tool_name] = int(counts.get(tool_name, 0))
             rows.append(row)
         return rows
 

--- a/dashboard/tests/test_ingestor.py
+++ b/dashboard/tests/test_ingestor.py
@@ -165,6 +165,10 @@ def test_projector_parses_feel_desires_completion_metrics() -> None:
         "logger": "ego_mcp.server",
         "message": "Tool execution completed",
         "tool_name": "feel_desires",
+        "emotion_primary": "curious",
+        "emotion_intensity": 0.65,
+        "valence": 0.2,
+        "arousal": 0.7,
         "time_phase": "night",
         "tool_output": (
             "information_hunger[0.8/high] social_thirst[0.4/mid] "
@@ -180,7 +184,11 @@ def test_projector_parses_feel_desires_completion_metrics() -> None:
     assert event is not None
     assert event.tool_name == "feel_desires"
     assert event.ok is True
+    assert event.emotion_primary == "curious"
+    assert event.emotion_intensity == 0.65
     assert event.string_metrics["time_phase"] == "night"
+    assert event.numeric_metrics["valence"] == 0.2
+    assert event.numeric_metrics["arousal"] == 0.7
     assert event.numeric_metrics["information_hunger"] == 0.8
     assert event.numeric_metrics["social_thirst"] == 0.4
     assert event.numeric_metrics["cognitive_coherence"] == 0.2

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -38,8 +38,11 @@ def test_tool_usage_and_metric_history() -> None:
     intensity = store.metric_history("intensity", start, end, bucket="1m")
 
     assert usage[0]["feel_desires"] == 1
+    assert usage[0]["remember"] == 0
     assert usage[1]["feel_desires"] == 1
     assert usage[1]["remember"] == 1
+    assert usage[2]["feel_desires"] == 0
+    assert usage[2]["remember"] == 0
     assert intensity[0]["value"] == 0.3
     assert intensity[1]["value"] == 0.7
 


### PR DESCRIPTION
## Summary

- **Live tail**: auto scroll 機能の実装（`isNearBottom` + `logFeedPinned` 二重状態管理、タブ切替時の下端初期スクロール）
- **Tool usage グラフ**: データ欠損タイミングの分単位ゼロフィル（バックエンドで全バケット密出力）
- **Intensity テレメトリ**: `_completion_log_context()` を全ツール完了時に出力するよう拡大（`feel_desires` 限定 → 全ツール）
- **History グラフ**: モバイルラベル折り返し対応（`flex-wrap` + `break-words`）、Tooltip に `showAllSeries` で全メトリクスラベル常時表示
- **Now タブ**: tool calls を「過去24時間」から「本日/前日」（ブラウザタイムゾーン基準）に変更、error rate 削除
- **ステータスインジケーター**: 閾値変更（Active: 15分以内、Idle: 16〜60分、No recent activity: 60分超）
- **レーダーチャート**: 最大値を 1.0 に固定（`PolarRadiusAxis domain={[0, 1]}`）
- **Activity feed**: in-memory store 環境で API サーバー内にバックグラウンド ingestor スレッドを起動し、store インスタンスを共有するよう修正
- **ingestor**: `tail_jsonl_file` に `stop_event` パラメータを追加し graceful shutdown に対応

## 変更ファイル (23 files, +630/-163)

### ego-mcp
- `ego-mcp/src/ego_mcp/server.py` — テレメトリ出力対象を全ツールに拡大
- `ego-mcp/tests/test_server.py` — `_completion_log_context` の non-feel_desires テスト追加

### dashboard backend
- `dashboard/src/ego_dashboard/api.py` — in-memory ingestor バックグラウンドスレッド起動・停止
- `dashboard/src/ego_dashboard/ingestor.py` — `stop_event` パラメータ追加
- `dashboard/src/ego_dashboard/sql_store.py` — ゼロフィル改善
- `dashboard/src/ego_dashboard/store.py` — ゼロフィル改善
- `dashboard/tests/test_api.py` — API テスト追加（エンドポイント + CORS + ingestor 起動）
- `dashboard/tests/test_ingestor.py` — feel_desires completion テスト拡充
- `dashboard/tests/test_store.py` — ゼロフィル検証追加

### dashboard frontend
- `dashboard/frontend/src/components/logs/logs-tab.tsx` — auto scroll 実装
- `dashboard/frontend/src/components/ui/scroll-area.tsx` — `viewportRef` + `onViewportScroll` 対応
- `dashboard/frontend/src/components/ui/chart.tsx` — `showAllSeries` + モバイルラベル対応
- `dashboard/frontend/src/components/now/session-summary.tsx` — 本日/前日の tool calls 表示
- `dashboard/frontend/src/components/now/status-indicator.tsx` — 閾値変更
- `dashboard/frontend/src/components/now/desire-radar.tsx` — 最大値 1.0 固定
- `dashboard/frontend/src/components/now/activity-feed.tsx` — WebSocket ログ表示
- `dashboard/frontend/src/hooks/use-dashboard-socket.ts` — WebSocket ログ受信・重複排除
- その他フロントエンドファイル

## Test plan

- [x] ego-mcp: `uv run pytest tests -v` — 267 passed
- [x] ego-mcp: `isort --check-only`, `ruff check`, `mypy` — all pass
- [x] dashboard backend: `uv run pytest -v` — 23 passed
- [x] dashboard backend: `ruff check`, `ruff format --check`, `mypy` — all pass
- [x] dashboard frontend: `npm run test` — 3 passed
- [x] dashboard frontend: `npm run lint`, `npm run format:check`, `npm run build` — all pass
- [x] `docker compose config` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)