### PR TITLE
Add time range presets and improve logger filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,15 +116,25 @@ If any code under `ego-mcp/` or `dashboard/` is changed, run the
 corresponding checks defined in `.github/workflows/ego-mcp-ci.yml`
 before finishing work.
 
+### Test addition rule
+
+**Every bug fix or new feature MUST include tests** that verify the changed behavior.
+- Backend fix → add/update test in `dashboard/tests/` or `ego-mcp/tests/`
+- Frontend fix → add/update test in `dashboard/frontend/src/`
+- A PR that changes behavior without tests will be rejected.
+
 ### ego-mcp CI sequence
+
+CI runs with Python 3.11. Locally, `ego-mcp/.python-version` pins 3.14, so
+use `UV_PYTHON=3.11` to match CI exactly:
 
 ```bash
 cd ego-mcp
-uv sync --extra dev
-GEMINI_API_KEY=test-key uv run pytest tests -v
-uv run isort --check-only src tests
-uv run ruff check src tests
-uv run mypy src tests
+UV_PYTHON=3.11 uv sync --extra dev
+UV_PYTHON=3.11 GEMINI_API_KEY=test-key uv run pytest tests -v
+UV_PYTHON=3.11 uv run isort --check-only src tests
+UV_PYTHON=3.11 uv run ruff check src tests
+UV_PYTHON=3.11 uv run mypy src tests
 ```
 
 ### dashboard backend CI sequence

--- a/dashboard/frontend/src/App.test.tsx
+++ b/dashboard/frontend/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import App from './App'
 
@@ -55,5 +56,12 @@ describe('App', () => {
   it('shows desire radar chart section', async () => {
     render(<App />)
     expect(await screen.findByText('Desire parameters')).toBeInTheDocument()
+  })
+
+  it('shows logs tab with live tail heading and default logger filter', async () => {
+    render(<App />)
+    await userEvent.click(screen.getByRole('tab', { name: 'Logs' }))
+    expect(await screen.findByText('Live tail')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('logger')).toHaveValue('ego_mcp.server')
   })
 })

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -78,7 +78,11 @@ const App = () => {
         </TabsContent>
 
         <TabsContent value="logs">
-          <LogsTab range={range} isActive={activeTab === 'logs'} />
+          <LogsTab
+            range={range}
+            preset={preset}
+            isActive={activeTab === 'logs'}
+          />
         </TabsContent>
       </Tabs>
     </main>

--- a/dashboard/frontend/src/components/logs/logs-tab.tsx
+++ b/dashboard/frontend/src/components/logs/logs-tab.tsx
@@ -12,10 +12,11 @@ import {
 } from '@/components/ui/select'
 import { useLogData } from '@/hooks/use-log-data'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
-import type { DateRange } from '@/types'
+import type { DateRange, TimeRangePreset } from '@/types'
 
 type LogsTabProps = {
   range: DateRange
+  preset: TimeRangePreset
   isActive: boolean
 }
 
@@ -39,7 +40,7 @@ const levelVariant = (
 const isNearBottom = (el: HTMLElement, threshold = 24) =>
   el.scrollHeight - el.scrollTop - el.clientHeight <= threshold
 
-export const LogsTab = ({ range, isActive }: LogsTabProps) => {
+export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
   const [logLevel, setLogLevel] = useState('ALL')
   const [loggerFilter, setLoggerFilter] = useState('')
   const [autoScroll, setAutoScroll] = useState(true)
@@ -47,7 +48,7 @@ export const LogsTab = ({ range, isActive }: LogsTabProps) => {
   const logViewportRef = useRef<HTMLDivElement | null>(null)
   const { formatTs, clientTimeZone } = useTimestampFormatter()
 
-  const logs = useLogData(isActive, range, logLevel, loggerFilter)
+  const logs = useLogData(isActive, preset, range, logLevel, loggerFilter)
 
   useEffect(() => {
     if (!isActive || !autoScroll || !logFeedPinned) return

--- a/dashboard/frontend/src/components/logs/logs-tab.tsx
+++ b/dashboard/frontend/src/components/logs/logs-tab.tsx
@@ -42,7 +42,7 @@ const isNearBottom = (el: HTMLElement, threshold = 24) =>
 
 export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
   const [logLevel, setLogLevel] = useState('ALL')
-  const [loggerFilter, setLoggerFilter] = useState('')
+  const [loggerFilter, setLoggerFilter] = useState('ego_mcp.server')
   const [autoScroll, setAutoScroll] = useState(true)
   const [logFeedPinned, setLogFeedPinned] = useState(true)
   const logViewportRef = useRef<HTMLDivElement | null>(null)

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -230,11 +230,11 @@ class SqlTelemetryStore:
                         """
                         SELECT ts, level, logger, message, private, fields
                         FROM log_events
-                        WHERE ts >= %s AND ts <= %s AND level = %s AND logger = %s
+                        WHERE ts >= %s AND ts <= %s AND level = %s AND logger ILIKE %s
                         ORDER BY ts ASC
                         LIMIT 300
                         """,
-                        (start, end, level.upper(), logger),
+                        (start, end, level.upper(), f"%{logger}%"),
                     )
                 elif level:
                     cur.execute(
@@ -252,11 +252,11 @@ class SqlTelemetryStore:
                         """
                         SELECT ts, level, logger, message, private, fields
                         FROM log_events
-                        WHERE ts >= %s AND ts <= %s AND logger = %s
+                        WHERE ts >= %s AND ts <= %s AND logger ILIKE %s
                         ORDER BY ts ASC
                         LIMIT 300
                         """,
-                        (start, end, logger),
+                        (start, end, f"%{logger}%"),
                     )
                 else:
                     cur.execute(

--- a/dashboard/src/ego_dashboard/store.py
+++ b/dashboard/src/ego_dashboard/store.py
@@ -110,7 +110,7 @@ class TelemetryStore:
         if level:
             values = [log for log in values if log.level == level.upper()]
         if logger:
-            values = [log for log in values if log.logger == logger]
+            values = [log for log in values if logger.lower() in log.logger.lower()]
         rows: list[dict[str, object]] = []
         for item in values[-300:]:
             row = item.model_dump(mode="json")

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -47,8 +47,12 @@ def test_logs_endpoint_logger_filter_returns_partial_matches() -> None:
 
     store = TelemetryStore()
     base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
-    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="hello", private=False))
-    store.ingest_log(LogEvent(ts=base, level="INFO", logger="other.module", message="world", private=False))
+    store.ingest_log(
+        LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="hello", private=False)
+    )
+    store.ingest_log(
+        LogEvent(ts=base, level="INFO", logger="other.module", message="world", private=False)
+    )
 
     app = create_app(store)
     client = TestClient(app)

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -42,6 +42,32 @@ def test_history_endpoints() -> None:
     assert client.get(f"/api/v1/alerts/anomalies?{query}&bucket=1m").status_code == 200
 
 
+def test_logs_endpoint_logger_filter_returns_partial_matches() -> None:
+    from ego_dashboard.models import LogEvent
+
+    store = TelemetryStore()
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="hello", private=False))
+    store.ingest_log(LogEvent(ts=base, level="INFO", logger="other.module", message="world", private=False))
+
+    app = create_app(store)
+    client = TestClient(app)
+
+    query = "from=2026-01-01T12:00:00Z&to=2026-01-01T12:02:00Z"
+
+    # Partial logger name matches only ego_mcp.server
+    response = client.get(f"/api/v1/logs?{query}&logger=ego_mcp")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["logger"] == "ego_mcp.server"
+
+    # No logger filter returns all logs
+    response = client.get(f"/api/v1/logs?{query}")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 2
+
+
 def test_cors_preflight_allows_configured_origin() -> None:
     app = create_app(
         TelemetryStore(),

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -100,9 +100,15 @@ def test_logs_logger_filter_substring_match() -> None:
     store = TelemetryStore()
     base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     end = base + timedelta(minutes=1)
-    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="a", private=False))
-    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.tool_handler", message="b", private=False))
-    store.ingest_log(LogEvent(ts=base, level="INFO", logger="other.module", message="c", private=False))
+    store.ingest_log(
+        LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="a", private=False)
+    )
+    store.ingest_log(
+        LogEvent(ts=base, level="INFO", logger="ego_mcp.tool_handler", message="b", private=False)
+    )
+    store.ingest_log(
+        LogEvent(ts=base, level="INFO", logger="other.module", message="c", private=False)
+    )
 
     # Partial match: "ego_mcp" matches both ego_mcp.* loggers
     result = store.logs(base, end, logger="ego_mcp")

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -94,6 +94,35 @@ def test_logs_filtering() -> None:
     assert info_logs[0]["fields"] == {"tool_name": "remember"}
 
 
+def test_logs_logger_filter_substring_match() -> None:
+    from ego_dashboard.models import LogEvent
+
+    store = TelemetryStore()
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    end = base + timedelta(minutes=1)
+    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.server", message="a", private=False))
+    store.ingest_log(LogEvent(ts=base, level="INFO", logger="ego_mcp.tool_handler", message="b", private=False))
+    store.ingest_log(LogEvent(ts=base, level="INFO", logger="other.module", message="c", private=False))
+
+    # Partial match: "ego_mcp" matches both ego_mcp.* loggers
+    result = store.logs(base, end, logger="ego_mcp")
+    assert len(result) == 2
+    assert {r["logger"] for r in result} == {"ego_mcp.server", "ego_mcp.tool_handler"}
+
+    # Case-insensitive match
+    result = store.logs(base, end, logger="EGO_MCP")
+    assert len(result) == 2
+
+    # More specific suffix still works
+    result = store.logs(base, end, logger="ego_mcp.server")
+    assert len(result) == 1
+    assert result[0]["logger"] == "ego_mcp.server"
+
+    # No match
+    result = store.logs(base, end, logger="nonexistent")
+    assert len(result) == 0
+
+
 def test_current_backfills_latest_emotion_from_recent_telemetry() -> None:
     store = TelemetryStore()
     store.ingest(_event(0, "remember", 0.8, "night"))


### PR DESCRIPTION
## Summary
This PR enhances the logs feature with time range presets (15m, 1h, 6h, 24h, 7d) that automatically update to show a rolling window ending at "now", and improves logger filtering to support substring matching instead of exact matches.

## Key Changes

- **Time Range Presets**: Added support for preset time ranges that dynamically compute the date range on each poll, ensuring the window always ends at the current time and new logs aren't excluded
  - Presets: 15m, 1h, 6h, 24h, 7d
  - Custom range option still available for manual date selection
  - Implemented in `useLogData` hook with `PRESET_MINUTES` mapping

- **Logger Filter Improvements**: Changed logger filtering from exact match to case-insensitive substring matching
  - Backend: Updated SQL queries to use `ILIKE` with wildcard patterns (`%logger%`)
  - Backend: Updated in-memory store to use case-insensitive substring matching
  - Frontend: Set default logger filter to `'ego_mcp.server'` for better UX

- **Component Updates**:
  - `LogsTab` now accepts `preset` prop and passes it to `useLogData`
  - `App.tsx` passes the `preset` state to `LogsTab`
  - Updated hook dependency array to use `preset` instead of `range` for presets

- **Tests**: Added comprehensive test coverage for logger substring filtering in both API and store layers

## Implementation Details

- The `useLogData` hook uses `useRef` to track the custom range while computing fresh preset ranges on each poll cycle
- Logger filter uses `%{logger}%` SQL pattern and case-insensitive comparison for flexible matching
- Default logger filter set to `'ego_mcp.server'` to provide immediate useful output

https://claude.ai/code/session_019wMqiH25vfNh8CNDQiUXsK