### PR TITLE
Fix mobile width overflow in dashboard Activity feed

### DIFF
--- a/dashboard/frontend/src/components/now/activity-feed.test.tsx
+++ b/dashboard/frontend/src/components/now/activity-feed.test.tsx
@@ -15,4 +15,25 @@ describe('ActivityFeed', () => {
 
     expect(screen.getByText('WebSocket')).toBeInTheDocument()
   })
+
+  it('truncates long tool names to avoid horizontal overflow', () => {
+    render(
+      <ActivityFeed
+        connected={true}
+        logLines={[
+          {
+            ts: '2025-01-01T00:00:00.000Z',
+            ok: true,
+            tool_name: 'this-is-an-extremely-long-tool-name-for-mobile-layouts',
+            message: 'example',
+          },
+        ]}
+      />,
+    )
+
+    const toolBadge = screen.getByText(
+      'this-is-an-extremely-long-tool-name-for-mobile-layouts',
+    )
+    expect(toolBadge).toHaveClass('max-w-[8rem]', 'truncate')
+  })
 })

--- a/dashboard/frontend/src/components/now/activity-feed.tsx
+++ b/dashboard/frontend/src/components/now/activity-feed.tsx
@@ -41,13 +41,16 @@ export const ActivityFeed = ({ logLines, connected }: ActivityFeedProps) => {
             {logLines.map((item, i) => (
               <div
                 key={`${item.ts}-${i}`}
-                className="flex items-start gap-2 text-xs"
+                className="flex min-w-0 items-start gap-2 text-xs"
               >
                 <span className="text-muted-foreground shrink-0 font-mono">
                   {formatTs(item.ts)}
                 </span>
                 {item.tool_name && (
-                  <Badge variant="outline" className="text-[10px]">
+                  <Badge
+                    variant="outline"
+                    className="max-w-[8rem] truncate text-[10px]"
+                  >
                     {item.tool_name}
                   </Badge>
                 )}
@@ -58,7 +61,10 @@ export const ActivityFeed = ({ logLines, connected }: ActivityFeedProps) => {
                   {item.ok ? 'ok' : 'error'}
                 </Badge>
                 {item.level && !item.tool_name && (
-                  <Badge variant="outline" className="text-[10px]">
+                  <Badge
+                    variant="outline"
+                    className="max-w-[8rem] truncate text-[10px]"
+                  >
                     {item.level}
                   </Badge>
                 )}


### PR DESCRIPTION
### Motivation
- Prevent Activity feed rows from forcing horizontal expansion on small/mobile viewports by ensuring badge and flex item sizes do not overflow their container.

### Description
- Add `min-w-0` to the Activity feed row container to allow flex children to shrink instead of forcing parent width (`dashboard/frontend/src/components/now/activity-feed.tsx`).
- Constrain long `tool_name` and `level` badges with `max-w-[8rem]` and `truncate` so they don't cause horizontal overflow (`dashboard/frontend/src/components/now/activity-feed.tsx`).
- Add a frontend unit test that renders a very long tool name and asserts the badge has the truncation classes (`dashboard/frontend/src/components/now/activity-feed.test.tsx`).

### Testing
- Frontend: ran `npm ci`, `npm run lint` (completed with 3 warnings), `npm run format:check` (passed), `npm run test` (Vitest: all tests passed), and `npm run build` (build succeeded).
- Backend: ran `uv sync --group dev`, `uv run pytest -v` (`29 passed`), `uv run ruff check src tests` (passed), `uv run ruff format --check src tests` (passed), and `uv run mypy src tests` (passed).
- `docker compose config` was attempted but failed in this environment because the `docker` command is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a398aa35fc83248a1605911b5b18f2)