### PR TITLE
feat: Dashboard テレメトリ修正・感情マッピング・CircumplexChart (v0.2.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,14 @@ __pycache__/
 # IDE / Editor
 .mcp.json
 
-# Working design docs
-design/wip/
-
-# task
-tasks/
+# Working design docs & tasks
+/design/wip/
+/tasks/
 
 # Env
 .env
 .env.*
 !.env.example
+
+# Logs (project root only)
+/logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ego-mcp のリリース履歴。
 
+## [0.2.8] - 2026-03-01
+
+### Fixed
+- Dashboard ingestor が全ツールの完了ログから感情データを取り込むように修正
+- Dashboard Activity feed の WebSocket レースコンディションを修正（StrictMode 二重マウント対応）
+
+### Added
+- 感情ラベルから intensity / valence / arousal への自動マッピング（`EMOTION_DEFAULTS`）
+
+### Changed
+- Dashboard Live tail のロガーフィルターをコンテンツ検索に置き換え
+- Dashboard Emotional state に Valence / Arousal のラッセル円環モデル表示を追加
+
 ## [0.2.7] - 2026-02-28
 
 ### Fixed

--- a/dashboard/docs/api.md
+++ b/dashboard/docs/api.md
@@ -16,7 +16,7 @@
   - string メトリクスの時系列点列
 - `GET /api/v1/metrics/{key}/heatmap?from=...&to=...&bucket=...`
   - string 値ごとの出現頻度
-- `GET /api/v1/logs?from=...&to=...&level=INFO&logger=name`
+- `GET /api/v1/logs?from=...&to=...&level=INFO&search=remember`
   - live tail / 履歴表示用ログ（最大 300 行）
 - `GET /api/v1/alerts/anomalies?from=...&to=...&bucket=...`
   - usage/intensity 急増検知

--- a/dashboard/docs/getting-started.md
+++ b/dashboard/docs/getting-started.md
@@ -36,7 +36,7 @@ docker compose up --build
 
 - `Now` タブが初期表示される
 - `History` タブに tool usage / string 可視化が表示される
-- `Logs` タブで level / logger フィルタが動作する
+- `Logs` タブで level / search フィルタが動作する
 
 ## 運用者向け
 
@@ -66,7 +66,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  C["Logs"] --> C1["level/logger filters"]
+  C["Logs"] --> C1["level/search filters"]
   C --> C2["live tail list"]
   C --> C3["private masking (REDACTED)"]
 ```

--- a/dashboard/frontend/src/App.test.tsx
+++ b/dashboard/frontend/src/App.test.tsx
@@ -58,10 +58,10 @@ describe('App', () => {
     expect(await screen.findByText('Desire parameters')).toBeInTheDocument()
   })
 
-  it('shows logs tab with live tail heading and default logger filter', async () => {
+  it('shows logs tab with live tail heading and default search filter', async () => {
     render(<App />)
     await userEvent.click(screen.getByRole('tab', { name: 'Logs' }))
     expect(await screen.findByText('Live tail')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('logger')).toHaveValue('ego_mcp.server')
+    expect(screen.getByPlaceholderText('search logs...')).toHaveValue('')
   })
 })

--- a/dashboard/frontend/src/api.test.ts
+++ b/dashboard/frontend/src/api.test.ts
@@ -36,4 +36,22 @@ describe('api.fetchLogs', () => {
     expect(logs[0]?.tool_name).toBe('remember')
     expect(logs[0]?.ok).toBe(true)
   })
+
+  it('uses search query parameter for filtered log fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    } as Response)
+
+    await fetchLogs(
+      { from: '2026-01-01T12:00:00Z', to: '2026-01-01T12:10:00Z' },
+      'INFO',
+      'remember',
+    )
+    const url = String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0] ?? '')
+
+    expect(url).toContain('level=INFO')
+    expect(url).toContain('search=remember')
+    expect(url).not.toContain('logger=')
+  })
 })

--- a/dashboard/frontend/src/api.ts
+++ b/dashboard/frontend/src/api.ts
@@ -115,12 +115,12 @@ export async function fetchLogs(): Promise<LogLine[]>
 export async function fetchLogs(
   range: DateRange,
   level: string,
-  logger: string,
+  search: string,
 ): Promise<LogPoint[]>
 export async function fetchLogs(
   range?: DateRange,
   level = 'ALL',
-  logger = '',
+  search = '',
 ): Promise<LogLine[] | LogPoint[]> {
   if (range == null) {
     const now = new Date()
@@ -133,9 +133,9 @@ export async function fetchLogs(
   }
 
   const levelQuery = level === 'ALL' ? '' : `&level=${level}`
-  const loggerQuery = logger ? `&logger=${encodeURIComponent(logger)}` : ''
+  const searchQuery = search ? `&search=${encodeURIComponent(search)}` : ''
   const data = await get<{ items: LogPoint[] }>(
-    `/api/v1/logs?${encodeRange(range)}${levelQuery}${loggerQuery}`,
+    `/api/v1/logs?${encodeRange(range)}${levelQuery}${searchQuery}`,
     {
       items: [],
     },

--- a/dashboard/frontend/src/components/logs/logs-tab.tsx
+++ b/dashboard/frontend/src/components/logs/logs-tab.tsx
@@ -42,13 +42,13 @@ const isNearBottom = (el: HTMLElement, threshold = 24) =>
 
 export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
   const [logLevel, setLogLevel] = useState('ALL')
-  const [loggerFilter, setLoggerFilter] = useState('ego_mcp.server')
+  const [searchFilter, setSearchFilter] = useState('')
   const [autoScroll, setAutoScroll] = useState(true)
   const [logFeedPinned, setLogFeedPinned] = useState(true)
   const logViewportRef = useRef<HTMLDivElement | null>(null)
   const { formatTs, clientTimeZone } = useTimestampFormatter()
 
-  const logs = useLogData(isActive, preset, range, logLevel, loggerFilter)
+  const logs = useLogData(isActive, preset, range, logLevel, searchFilter)
 
   useEffect(() => {
     if (!isActive || !autoScroll || !logFeedPinned) return
@@ -91,9 +91,9 @@ export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
           </Select>
           <input
             className="rounded-md border border-input bg-secondary px-2 py-1 text-sm"
-            placeholder="logger"
-            value={loggerFilter}
-            onChange={(e) => setLoggerFilter(e.target.value)}
+            placeholder="search logs..."
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
           />
           <label className="flex items-center gap-1.5 text-xs">
             <input
@@ -115,6 +115,9 @@ export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
           <div className="space-y-2">
             {logs.map((item, index) => {
               const { ts, level, ...rest } = item
+              const displayPayload = Object.fromEntries(
+                Object.entries(rest).filter(([key]) => key !== 'logger'),
+              )
               return (
                 <div
                   key={`log-${ts}-${String(item.logger)}-${index}`}
@@ -133,7 +136,7 @@ export const LogsTab = ({ range, preset, isActive }: LogsTabProps) => {
                     {formatTs(ts)}
                   </div>
                   <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
-                    {JSON.stringify(rest, null, 2)}
+                    {JSON.stringify(displayPayload, null, 2)}
                   </pre>
                 </div>
               )

--- a/dashboard/frontend/src/components/now/circumplex-chart.test.tsx
+++ b/dashboard/frontend/src/components/now/circumplex-chart.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+
+import { CircumplexChart } from '@/components/now/circumplex-chart'
+
+describe('CircumplexChart', () => {
+  it('renders dot when valence/arousal are provided', () => {
+    render(<CircumplexChart valence={0.5} arousal={0.8} />)
+
+    expect(screen.getByTestId('circumplex-dot')).toBeInTheDocument()
+    expect(screen.getByText(/v: 0.50/i)).toBeInTheDocument()
+    expect(screen.getByText(/a: 0.80/i)).toBeInTheDocument()
+  })
+
+  it('renders n/a when valence/arousal are null', () => {
+    render(<CircumplexChart valence={null} arousal={null} />)
+
+    expect(screen.getByTestId('circumplex-na')).toBeInTheDocument()
+    expect(screen.queryByTestId('circumplex-dot')).not.toBeInTheDocument()
+  })
+
+  it('renders n/a when valence/arousal are undefined', () => {
+    render(<CircumplexChart valence={undefined} arousal={undefined} />)
+
+    expect(screen.getByTestId('circumplex-na')).toBeInTheDocument()
+    expect(screen.queryByTestId('circumplex-dot')).not.toBeInTheDocument()
+  })
+
+  it('supports boundary values', () => {
+    const { rerender } = render(
+      <CircumplexChart valence={-1.0} arousal={0.0} />,
+    )
+    expect(screen.getByTestId('circumplex-dot')).toBeInTheDocument()
+
+    rerender(<CircumplexChart valence={1.0} arousal={1.0} />)
+    expect(screen.getByTestId('circumplex-dot')).toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/now/circumplex-chart.tsx
+++ b/dashboard/frontend/src/components/now/circumplex-chart.tsx
@@ -1,0 +1,120 @@
+type CircumplexChartProps = {
+  valence: number | null | undefined
+  arousal: number | null | undefined
+  size?: number
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value))
+
+export const CircumplexChart = ({
+  valence,
+  arousal,
+  size = 120,
+}: CircumplexChartProps) => {
+  const center = size / 2
+  const radius = Math.max(8, center - 16)
+  const hasPoint = valence != null && arousal != null
+  const safeValence = clamp(valence ?? 0, -1, 1)
+  const safeArousal = clamp(arousal ?? 0.5, 0, 1)
+  const cx = center + safeValence * radius
+  const cy = center - (safeArousal - 0.5) * 2 * radius
+
+  return (
+    <div
+      data-testid="circumplex-chart"
+      className="flex flex-col items-center gap-1"
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+      >
+        <title>Valence-arousal circumplex chart</title>
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth="1.5"
+        />
+        <line
+          x1={center - radius}
+          y1={center}
+          x2={center + radius}
+          y2={center}
+          stroke="var(--color-border)"
+          strokeDasharray="4 4"
+          strokeWidth="1"
+        />
+        <line
+          x1={center}
+          y1={center - radius}
+          x2={center}
+          y2={center + radius}
+          stroke="var(--color-border)"
+          strokeDasharray="4 4"
+          strokeWidth="1"
+        />
+        <text
+          x={center}
+          y={12}
+          textAnchor="middle"
+          className="fill-muted-foreground text-[9px]"
+        >
+          aroused
+        </text>
+        <text
+          x={center}
+          y={size - 4}
+          textAnchor="middle"
+          className="fill-muted-foreground text-[9px]"
+        >
+          calm
+        </text>
+        <text
+          x={6}
+          y={center + 3}
+          textAnchor="start"
+          className="fill-muted-foreground text-[9px]"
+        >
+          unpleasant
+        </text>
+        <text
+          x={size - 6}
+          y={center + 3}
+          textAnchor="end"
+          className="fill-muted-foreground text-[9px]"
+        >
+          pleasant
+        </text>
+        {hasPoint ? (
+          <circle
+            data-testid="circumplex-dot"
+            cx={cx}
+            cy={cy}
+            r="4"
+            fill="var(--color-chart-2)"
+          />
+        ) : (
+          <text
+            data-testid="circumplex-na"
+            x={center}
+            y={center + 4}
+            textAnchor="middle"
+            className="fill-muted-foreground text-xs"
+          >
+            n/a
+          </text>
+        )}
+      </svg>
+      <p className="text-muted-foreground text-xs tabular-nums">
+        {hasPoint
+          ? `v: ${safeValence?.toFixed(2)} / a: ${safeArousal?.toFixed(2)}`
+          : 'n/a'}
+      </p>
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/now/emotion-status.test.tsx
+++ b/dashboard/frontend/src/components/now/emotion-status.test.tsx
@@ -36,8 +36,9 @@ describe('EmotionStatus', () => {
 
     expect(screen.getByText('curious')).toBeInTheDocument()
     expect(screen.getByText('0.70')).toBeInTheDocument()
-    expect(screen.getByText('0.40')).toBeInTheDocument()
-    expect(screen.getByText('0.80')).toBeInTheDocument()
+    expect(screen.getByTestId('circumplex-chart')).toBeInTheDocument()
+    expect(screen.getByText(/v: 0.40/i)).toBeInTheDocument()
+    expect(screen.getByText(/a: 0.80/i)).toBeInTheDocument()
     expect(screen.getByText(/5m ago/)).toBeInTheDocument()
   })
 
@@ -56,9 +57,9 @@ describe('EmotionStatus', () => {
 
     render(<EmotionStatus current={current} />)
 
-    expect(screen.getByText('calm')).toBeInTheDocument()
+    expect(screen.getByText('calm', { selector: 'span' })).toBeInTheDocument()
     expect(screen.getByText('0.60')).toBeInTheDocument()
-    expect(screen.getByText('0.20')).toBeInTheDocument()
-    expect(screen.getByText('0.30')).toBeInTheDocument()
+    expect(screen.getByText(/v: 0.20/i)).toBeInTheDocument()
+    expect(screen.getByText(/a: 0.30/i)).toBeInTheDocument()
   })
 })

--- a/dashboard/frontend/src/components/now/emotion-status.tsx
+++ b/dashboard/frontend/src/components/now/emotion-status.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { CircumplexChart } from '@/components/now/circumplex-chart'
 import type { CurrentResponse } from '@/types'
 
 type EmotionStatusProps = {
@@ -38,38 +39,31 @@ export const EmotionStatus = ({ current }: EmotionStatusProps) => {
         {age && <span className="text-muted-foreground text-xs">{age}</span>}
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <div>
-            <p className="text-muted-foreground mb-1 text-xs">emotion</p>
-            <Badge variant="secondary" className="text-sm">
-              {emotion}
-            </Badge>
-          </div>
-          <div>
-            <p className="text-muted-foreground mb-1 text-xs">intensity</p>
-            <div className="flex items-center gap-2">
-              <div className="bg-secondary h-2 flex-1 overflow-hidden rounded-full">
-                <div
-                  className="bg-primary h-full rounded-full transition-all"
-                  style={{ width: `${intensity * 100}%` }}
-                />
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+          <div className="space-y-4">
+            <div>
+              <p className="text-muted-foreground mb-1 text-xs">emotion</p>
+              <Badge variant="secondary" className="text-sm">
+                {emotion}
+              </Badge>
+            </div>
+            <div>
+              <p className="text-muted-foreground mb-1 text-xs">intensity</p>
+              <div className="flex items-center gap-2">
+                <div className="bg-secondary h-2 flex-1 overflow-hidden rounded-full">
+                  <div
+                    className="bg-primary h-full rounded-full transition-all"
+                    style={{ width: `${intensity * 100}%` }}
+                  />
+                </div>
+                <span className="text-xs tabular-nums">
+                  {intensity.toFixed(2)}
+                </span>
               </div>
-              <span className="text-xs tabular-nums">
-                {intensity.toFixed(2)}
-              </span>
             </div>
           </div>
-          <div>
-            <p className="text-muted-foreground mb-1 text-xs">valence</p>
-            <span className="text-sm font-medium tabular-nums">
-              {valence != null ? valence.toFixed(2) : 'n/a'}
-            </span>
-          </div>
-          <div>
-            <p className="text-muted-foreground mb-1 text-xs">arousal</p>
-            <span className="text-sm font-medium tabular-nums">
-              {arousal != null ? arousal.toFixed(2) : 'n/a'}
-            </span>
+          <div className="flex justify-center md:justify-end">
+            <CircumplexChart valence={valence} arousal={arousal} />
           </div>
         </div>
       </CardContent>

--- a/dashboard/frontend/src/hooks/use-log-data.ts
+++ b/dashboard/frontend/src/hooks/use-log-data.ts
@@ -16,7 +16,7 @@ export const useLogData = (
   preset: TimeRangePreset,
   range: DateRange,
   logLevel: string,
-  loggerFilter: string,
+  searchFilter: string,
 ) => {
   const [logs, setLogs] = useState<LogPoint[]>([])
   const rangeRef = useRef(range)
@@ -38,7 +38,7 @@ export const useLogData = (
         from.setMinutes(from.getMinutes() - PRESET_MINUTES[preset])
         currentRange = { from: from.toISOString(), to: to.toISOString() }
       }
-      const data = await fetchLogs(currentRange, logLevel, loggerFilter)
+      const data = await fetchLogs(currentRange, logLevel, searchFilter)
       if (!disposed) {
         setLogs(data)
       }
@@ -49,7 +49,7 @@ export const useLogData = (
       disposed = true
       clearInterval(timer)
     }
-  }, [enabled, preset, logLevel, loggerFilter])
+  }, [enabled, preset, logLevel, searchFilter])
 
   return logs
 }

--- a/dashboard/src/ego_dashboard/api.py
+++ b/dashboard/src/ego_dashboard/api.py
@@ -32,7 +32,12 @@ class StoreProtocol(Protocol):
     ) -> list[dict[str, object]]: ...
 
     def logs(
-        self, start: datetime, end: datetime, level: str | None = None, logger: str | None = None
+        self,
+        start: datetime,
+        end: datetime,
+        level: str | None = None,
+        *,
+        search: str | None = None,
     ) -> list[dict[str, object]]: ...
 
     def anomaly_alerts(
@@ -148,9 +153,9 @@ def create_app(
         from_ts: datetime = Query(alias="from"),
         to_ts: datetime = Query(alias="to"),
         level: str | None = None,
-        logger: str | None = None,
+        search: str | None = None,
     ) -> dict[str, object]:
-        return {"items": telemetry.logs(from_ts, to_ts, level, logger)}
+        return {"items": telemetry.logs(from_ts, to_ts, level, search=search)}
 
     @app.get("/api/v1/alerts/anomalies")
     def get_anomalies(
@@ -176,7 +181,7 @@ def create_app(
                 )
                 end = datetime.now(tz=UTC)
                 start = end - timedelta(minutes=5)
-                logs = telemetry.logs(start, end, None, None)
+                logs = telemetry.logs(start, end)
                 for log in logs:
                     log_key = json.dumps(
                         {

--- a/ego-mcp/docs/tool-reference.md
+++ b/ego-mcp/docs/tool-reference.md
@@ -187,7 +187,7 @@ If you're sharing a meaningful moment, capture it with remember(shared_with=...)
     },
     "intensity": {
       "type": "number",
-      "default": 0.5
+      "description": "Emotion intensity (0.0-1.0). Auto-derived from emotion label if omitted."
     },
     "importance": {
       "type": "integer",
@@ -199,11 +199,11 @@ If you're sharing a meaningful moment, capture it with remember(shared_with=...)
     },
     "valence": {
       "type": "number",
-      "default": 0.0
+      "description": "Valence on Russell's circumplex model (-1.0 to +1.0). Auto-derived from emotion label if omitted."
     },
     "arousal": {
       "type": "number",
-      "default": 0.5
+      "description": "Arousal on Russell's circumplex model (0.0 to 1.0). Auto-derived from emotion label if omitted."
     },
     "body_state": {
       "type": "object"
@@ -230,7 +230,9 @@ If you're sharing a meaningful moment, capture it with remember(shared_with=...)
 }
 ```
 
-**Available emotions:** `happy`, `sad`, `surprised`, `moved`, `excited`, `nostalgic`, `curious`, `neutral`, `melancholy`, `anxious`, `contentment`, `frustrated`
+**Available emotions:** `happy`, `sad`, `surprised`, `moved`, `excited`, `nostalgic`, `curious`, `neutral`, `melancholy`, `anxious`, `contentment`, `frustrated`, `calm`, `contemplative`, `thoughtful`, `grateful`, `vulnerable`, `content`, `fulfilled`, `touched`, `concerned`, `hopeful`, `peaceful`, `love`, `warm`, `lonely`, `afraid`, `ashamed`, `bored`
+
+> Since v0.2.8, `intensity`, `valence`, `arousal` are automatically derived from the emotion label via `EMOTION_DEFAULTS` when not explicitly specified. For example, `emotion="excited"` defaults to `intensity=0.8, valence=0.7, arousal=0.8`. Explicit values always take priority over the automatic mapping.
 
 **Response example:**
 

--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "0.2.7"
+version = "0.2.8"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.11"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/ego-mcp/uv.lock
+++ b/ego-mcp/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "ego-mcp"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Dashboard のテレメトリ表示に関する複数の問題を修正し、感情データの可視化を改善するリリース (v0.2.8)。

### 修正・改善内容

- **Ingestor 全ツール完了ログ対応**: `EgoMcpLogProjector.project()` が `feel_desires` 以外のツールの完了ログも処理するように修正。感情データ (valence/arousal/intensity) の取得頻度が約 4 倍に向上
- **感情ラベル自動マッピング (EMOTION_DEFAULTS)**: `remember` 実行時に emotion ラベルから intensity/valence/arousal を自動導出。28 種の感情ラベルに対応し、LLM が数値を省略しても適切な値が設定される
- **Live tail コンテンツ検索**: ロガーフィルターを廃止し、message + fields に対する部分一致検索に置き換え。`ego_mcp.server` 以外のログは取り込み段階でフィルタ
- **Russell 円環モデル表示 (CircumplexChart)**: Emotional state パネルに SVG ベースのラッセル円環モデルチャートを追加。valence/arousal の空間的な把握が可能に
- **WebSocket レースコンディション修正**: React StrictMode の二重マウントで HTTP Polling にフォールバックする問題を `epochRef` パターンで解決
- **ILIKE メタ文字エスケープ**: SqlTelemetryStore の検索で `%` / `_` メタ文字を適切にエスケープ
- **.gitignore 修正**: `logs/` パターンがサブディレクトリにもマッチする問題を修正 (`/logs/` に変更)
- **ドキュメント更新**: `dashboard/docs/`, `ego-mcp/docs/tool-reference.md` を v0.2.8 の変更に合わせて更新

## Test plan

- [ ] `ego-mcp` テスト (pytest 291 passed)
- [ ] `ego-mcp` lint/type check (isort, ruff, mypy all passed)
- [ ] `dashboard` バックエンドテスト (pytest 34 passed)
- [ ] `dashboard` バックエンド lint/type check (ruff, mypy all passed)
- [ ] `dashboard` フロントエンドテスト (vitest 19 passed)
- [ ] `dashboard` フロントエンド lint/format (eslint, prettier all passed)
- [ ] `dashboard` フロントエンドビルド成功
- [ ] `dashboard` docker-compose config 検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)