### PR TITLE
fix: 感情テレメトリ バグ修正 + データマイグレーション (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ego-mcp のリリース履歴。
 
+## [0.3.0] - 2026-03-01
+
+### Fixed
+- ego-mcp: `list_recent()` が ChromaDB の `get(limit=N)` の順序不定性により最新記憶を返さないバグを修正（全件取得→ソート→スライスに変更）
+- ego-mcp: `list_episodes()` も同様に全件取得→ソート→スライスに修正
+- ego-mcp: `EMOTION_DEFAULTS` に `"contentment"` / `"melancholy"` のエントリ追加（v0.2.0 での Emotion enum 追加時の漏れ）
+- Dashboard `sql_store.py` の valence/arousal クエリに `::double precision` キャスト追加、Python 側の型チェックを `(int, float)` に統一
+
+### Added
+- Dashboard ログベースマイグレーションスクリプト（`scripts/migrate_emotion_telemetry.py`）— completion テレメトリの壊れた感情データを invocation ログから再構築
+
+### Changed
+- バージョンアップ: ego-mcp 0.2.9→0.3.0
+
 ## [0.2.9] - 2026-03-01
 
 ### Added

--- a/dashboard/scripts/migrate_emotion_telemetry.py
+++ b/dashboard/scripts/migrate_emotion_telemetry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from ego_dashboard.migrate_emotion_telemetry import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/src/ego_dashboard/migrate_emotion_telemetry.py
+++ b/dashboard/src/ego_dashboard/migrate_emotion_telemetry.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+DEFAULT_EMOTION_VECTOR = (0.5, 0.0, 0.5)
+EMOTION_DEFAULTS: dict[str, tuple[float, float, float]] = {
+    # emotion: (intensity, valence, arousal)
+    "happy": (0.6, 0.6, 0.5),
+    "excited": (0.8, 0.7, 0.8),
+    "calm": (0.4, 0.3, 0.2),
+    "neutral": (0.3, 0.0, 0.3),
+    "curious": (0.6, 0.3, 0.6),
+    "contemplative": (0.5, 0.1, 0.3),
+    "thoughtful": (0.5, 0.1, 0.4),
+    "grateful": (0.6, 0.7, 0.4),
+    "vulnerable": (0.6, -0.3, 0.5),
+    "content": (0.5, 0.5, 0.2),
+    "fulfilled": (0.6, 0.6, 0.2),
+    "touched": (0.7, 0.5, 0.4),
+    "moved": (0.7, 0.5, 0.5),
+    "concerned": (0.5, -0.3, 0.5),
+    "hopeful": (0.6, 0.4, 0.5),
+    "peaceful": (0.4, 0.4, 0.1),
+    "love": (0.8, 0.8, 0.4),
+    "warm": (0.5, 0.5, 0.3),
+    "sad": (0.5, -0.6, 0.2),
+    "anxious": (0.7, -0.6, 0.8),
+    "angry": (0.8, -0.7, 0.9),
+    "frustrated": (0.7, -0.5, 0.7),
+    "lonely": (0.6, -0.6, 0.3),
+    "afraid": (0.8, -0.8, 0.9),
+    "ashamed": (0.6, -0.7, 0.4),
+    "bored": (0.3, -0.3, 0.1),
+    "nostalgic": (0.5, 0.1, 0.3),
+    "contentment": (0.5, 0.5, 0.2),
+    "melancholy": (0.5, -0.4, 0.2),
+    "surprised": (0.7, 0.1, 0.9),
+}
+
+
+@dataclass(frozen=True)
+class EmotionSnapshot:
+    ts: datetime
+    emotion_primary: str
+    intensity: float
+    valence: float
+    arousal: float
+
+
+@dataclass(frozen=True)
+class MigrationStats:
+    timeline_entries: int
+    cleared_completion_rows: int
+    updated_invocations: int
+    updated_completions: int
+
+
+def _parse_ts(raw_value: object) -> datetime | None:
+    if not isinstance(raw_value, str) or not raw_value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _float_or_default(value: object, default: float) -> float:
+    return float(value) if isinstance(value, (int, float)) else default
+
+
+def _normalize_emotion(raw_value: object) -> str:
+    if not isinstance(raw_value, str):
+        return "neutral"
+    normalized = raw_value.strip().lower()
+    return normalized or "neutral"
+
+
+def _to_tool_args(raw_value: object) -> dict[str, object]:
+    if isinstance(raw_value, dict):
+        return {str(key): value for key, value in raw_value.items()}
+    if isinstance(raw_value, str):
+        try:
+            parsed = json.loads(raw_value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return {str(key): value for key, value in parsed.items()}
+    return {}
+
+
+def _emotion_snapshot_from_args(ts: datetime, tool_args: dict[str, object]) -> EmotionSnapshot:
+    emotion_primary = _normalize_emotion(tool_args.get("emotion"))
+    defaults = EMOTION_DEFAULTS.get(emotion_primary, DEFAULT_EMOTION_VECTOR)
+    return EmotionSnapshot(
+        ts=ts,
+        emotion_primary=emotion_primary,
+        intensity=_float_or_default(tool_args.get("intensity"), defaults[0]),
+        valence=_float_or_default(tool_args.get("valence"), defaults[1]),
+        arousal=_float_or_default(tool_args.get("arousal"), defaults[2]),
+    )
+
+
+def build_emotion_timeline(log_dir: Path) -> list[EmotionSnapshot]:
+    timeline: list[EmotionSnapshot] = []
+    for log_path in sorted(log_dir.glob("ego-mcp-*.log")):
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("message") != "Tool invocation":
+                continue
+            if payload.get("tool_name") != "remember":
+                continue
+            raw_ts = payload.get("timestamp")
+            if raw_ts is None:
+                raw_ts = payload.get("ts")
+            ts = _parse_ts(raw_ts)
+            if ts is None:
+                continue
+            tool_args = _to_tool_args(payload.get("tool_args"))
+            timeline.append(_emotion_snapshot_from_args(ts, tool_args))
+    timeline.sort(key=lambda snapshot: snapshot.ts)
+    return timeline
+
+
+def find_latest_emotion_at(
+    timeline: list[EmotionSnapshot],
+    ts: datetime,
+) -> EmotionSnapshot | None:
+    latest: EmotionSnapshot | None = None
+    for snapshot in timeline:
+        if snapshot.ts > ts:
+            break
+        latest = snapshot
+    return latest
+
+
+def _rowcount(cursor: Any) -> int:
+    raw = getattr(cursor, "rowcount", 0)
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return 0
+
+
+def run_migration(
+    *,
+    log_dir: Path,
+    database_url: str,
+    dry_run: bool = False,
+) -> MigrationStats:
+    timeline = build_emotion_timeline(log_dir)
+    if not timeline:
+        return MigrationStats(
+            timeline_entries=0,
+            cleared_completion_rows=0,
+            updated_invocations=0,
+            updated_completions=0,
+        )
+
+    cleared_completion_rows = 0
+    updated_invocations = 0
+    updated_completions = 0
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            if not dry_run:
+                cur.execute(
+                    """
+                    UPDATE tool_events
+                    SET emotion_primary = NULL,
+                        emotion_intensity = NULL,
+                        numeric_metrics = numeric_metrics - 'intensity' - 'valence' - 'arousal'
+                    WHERE event_type = 'tool_call_completed'
+                      AND emotion_primary = 'neutral'
+                      AND emotion_intensity = 0.5
+                    """
+                )
+                cleared_completion_rows = _rowcount(cur)
+
+            cur.execute(
+                """
+                SELECT ts
+                FROM tool_events
+                WHERE event_type = 'tool_call_invoked'
+                  AND tool_name = 'remember'
+                ORDER BY ts ASC
+                """
+            )
+            invocation_rows = cur.fetchall()
+            for row in invocation_rows:
+                if not row:
+                    continue
+                ts = row[0]
+                if not isinstance(ts, datetime):
+                    continue
+                snapshot = find_latest_emotion_at(timeline, ts.astimezone(UTC))
+                if snapshot is None or dry_run:
+                    continue
+                cur.execute(
+                    """
+                    UPDATE tool_events
+                    SET emotion_primary = %s,
+                        emotion_intensity = %s,
+                        numeric_metrics = numeric_metrics || jsonb_build_object(
+                            'intensity', %s,
+                            'valence', %s,
+                            'arousal', %s
+                        )
+                    WHERE event_type = 'tool_call_invoked'
+                      AND tool_name = 'remember'
+                      AND ts = %s
+                    """,
+                    (
+                        snapshot.emotion_primary,
+                        snapshot.intensity,
+                        snapshot.intensity,
+                        snapshot.valence,
+                        snapshot.arousal,
+                        ts,
+                    ),
+                )
+                updated_invocations += _rowcount(cur)
+
+            cur.execute(
+                """
+                SELECT ts
+                FROM tool_events
+                WHERE event_type = 'tool_call_completed'
+                ORDER BY ts ASC
+                """
+            )
+            completion_rows = cur.fetchall()
+            for row in completion_rows:
+                if not row:
+                    continue
+                ts = row[0]
+                if not isinstance(ts, datetime):
+                    continue
+                snapshot = find_latest_emotion_at(timeline, ts.astimezone(UTC))
+                if snapshot is None or dry_run:
+                    continue
+                cur.execute(
+                    """
+                    UPDATE tool_events
+                    SET emotion_primary = %s,
+                        emotion_intensity = %s,
+                        numeric_metrics = numeric_metrics || jsonb_build_object(
+                            'intensity', %s,
+                            'valence', %s,
+                            'arousal', %s
+                        )
+                    WHERE event_type = 'tool_call_completed'
+                      AND ts = %s
+                      AND emotion_primary IS NULL
+                    """,
+                    (
+                        snapshot.emotion_primary,
+                        snapshot.intensity,
+                        snapshot.intensity,
+                        snapshot.valence,
+                        snapshot.arousal,
+                        ts,
+                    ),
+                )
+                updated_completions += _rowcount(cur)
+
+        if not dry_run:
+            conn.commit()
+
+    return MigrationStats(
+        timeline_entries=len(timeline),
+        cleared_completion_rows=cleared_completion_rows,
+        updated_invocations=updated_invocations,
+        updated_completions=updated_completions,
+    )
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Migrate emotion telemetry in dashboard SQL store")
+    parser.add_argument("--log-dir", type=Path, default=Path("/tmp"))
+    parser.add_argument("--database-url", type=str, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    database_url = args.database_url or os.getenv("DASHBOARD_DATABASE_URL")
+    if not isinstance(database_url, str) or not database_url:
+        parser.error("database URL is required via --database-url or DASHBOARD_DATABASE_URL")
+
+    stats = run_migration(
+        log_dir=args.log_dir,
+        database_url=database_url,
+        dry_run=args.dry_run,
+    )
+    mode = "dry-run" if args.dry_run else "apply"
+    print(
+        f"mode={mode} timeline_entries={stats.timeline_entries} "
+        f"cleared_completion_rows={stats.cleared_completion_rows} "
+        f"updated_invocations={stats.updated_invocations} "
+        f"updated_completions={stats.updated_completions}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -373,8 +373,8 @@ class SqlTelemetryStore:
                       ts,
                       emotion_primary,
                       emotion_intensity,
-                      numeric_metrics ->> 'valence',
-                      numeric_metrics ->> 'arousal'
+                      (numeric_metrics ->> 'valence')::double precision,
+                      (numeric_metrics ->> 'arousal')::double precision
                     FROM tool_events
                     WHERE ts <= %s
                       AND (emotion_primary IS NOT NULL OR emotion_intensity IS NOT NULL)
@@ -437,8 +437,8 @@ class SqlTelemetryStore:
                 valence_raw,
                 arousal_raw,
             ) = latest_emotion_row
-            valence = float(valence_raw) if isinstance(valence_raw, str) else None
-            arousal = float(arousal_raw) if isinstance(arousal_raw, str) else None
+            valence = float(valence_raw) if isinstance(valence_raw, (int, float)) else None
+            arousal = float(arousal_raw) if isinstance(arousal_raw, (int, float)) else None
             latest_emotion = {
                 "ts": emotion_ts.isoformat(),
                 "emotion_primary": str(emotion_primary) if emotion_primary is not None else None,

--- a/dashboard/tests/test_migrate_emotion_telemetry.py
+++ b/dashboard/tests/test_migrate_emotion_telemetry.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from ego_dashboard.migrate_emotion_telemetry import (
+    EmotionSnapshot,
+    build_emotion_timeline,
+    find_latest_emotion_at,
+    run_migration,
+)
+
+
+def _write_log(path: Path, rows: list[dict[str, object]]) -> None:
+    payload = "\n".join(json.dumps(row) for row in rows)
+    path.write_text(f"{payload}\n", encoding="utf-8")
+
+
+def test_build_emotion_timeline_uses_defaults_and_overrides(tmp_path: Path) -> None:
+    log_file = tmp_path / "ego-mcp-2026-03-01.log"
+    _write_log(
+        log_file,
+        [
+            {
+                "timestamp": "2026-03-01T00:00:00Z",
+                "message": "Tool invocation",
+                "tool_name": "remember",
+                "tool_args": {"emotion": "contentment"},
+            },
+            {
+                "timestamp": "2026-03-01T00:00:10Z",
+                "message": "Tool invocation",
+                "tool_name": "remember",
+                "tool_args": {
+                    "emotion": "melancholy",
+                    "intensity": 0.9,
+                    "valence": -0.2,
+                    "arousal": 0.4,
+                },
+            },
+            {
+                "timestamp": "2026-03-01T00:00:20Z",
+                "message": "Tool invocation",
+                "tool_name": "wake_up",
+                "tool_args": {},
+            },
+        ],
+    )
+
+    timeline = build_emotion_timeline(tmp_path)
+
+    assert len(timeline) == 2
+    assert timeline[0].emotion_primary == "contentment"
+    assert timeline[0].intensity == pytest.approx(0.5)
+    assert timeline[0].valence == pytest.approx(0.5)
+    assert timeline[0].arousal == pytest.approx(0.2)
+    assert timeline[1].emotion_primary == "melancholy"
+    assert timeline[1].intensity == pytest.approx(0.9)
+    assert timeline[1].valence == pytest.approx(-0.2)
+    assert timeline[1].arousal == pytest.approx(0.4)
+
+
+def test_find_latest_emotion_at_returns_most_recent_snapshot() -> None:
+    base = datetime(2026, 3, 1, 0, 0, tzinfo=UTC)
+    timeline = [
+        EmotionSnapshot(
+            ts=base,
+            emotion_primary="neutral",
+            intensity=0.3,
+            valence=0.0,
+            arousal=0.3,
+        ),
+        EmotionSnapshot(
+            ts=base + timedelta(seconds=30),
+            emotion_primary="curious",
+            intensity=0.6,
+            valence=0.3,
+            arousal=0.6,
+        ),
+    ]
+
+    assert find_latest_emotion_at(timeline, base - timedelta(seconds=1)) is None
+    latest = find_latest_emotion_at(timeline, base + timedelta(seconds=45))
+    assert latest is not None
+    assert latest.emotion_primary == "curious"
+    assert latest.intensity == pytest.approx(0.6)
+
+
+def test_dry_run_produces_no_sql_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "ego-mcp-2026-03-01.log"
+    _write_log(
+        log_file,
+        [
+            {
+                "timestamp": "2026-03-01T00:00:00Z",
+                "message": "Tool invocation",
+                "tool_name": "remember",
+                "tool_args": {"emotion": "curious"},
+            }
+        ],
+    )
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.executed_sql: list[str] = []
+
+        def execute(self, query: object, _params: object | None = None) -> None:
+            self.executed_sql.append(str(query))
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            sql = self.executed_sql[-1]
+            if "event_type = 'tool_call_invoked'" in sql:
+                return []
+            if "event_type = 'tool_call_completed'" in sql:
+                return []
+            return []
+
+        def __enter__(self) -> FakeCursor:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cursor_obj = FakeCursor()
+            self.commit_called = False
+
+        def cursor(self) -> FakeCursor:
+            return self.cursor_obj
+
+        def commit(self) -> None:
+            self.commit_called = True
+
+        def __enter__(self) -> FakeConnection:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    fake_connection = FakeConnection()
+    monkeypatch.setattr(
+        "ego_dashboard.migrate_emotion_telemetry.psycopg.connect",
+        lambda *_args, **_kwargs: fake_connection,
+    )
+
+    stats = run_migration(
+        log_dir=tmp_path,
+        database_url="postgresql://unused",
+        dry_run=True,
+    )
+
+    assert stats.timeline_entries == 1
+    assert stats.cleared_completion_rows == 0
+    assert stats.updated_invocations == 0
+    assert stats.updated_completions == 0
+    assert all(
+        not statement.lstrip().upper().startswith("UPDATE")
+        for statement in fake_connection.cursor_obj.executed_sql
+    )
+    assert fake_connection.commit_called is False

--- a/dashboard/tests/test_sql_store.py
+++ b/dashboard/tests/test_sql_store.py
@@ -101,7 +101,7 @@ def test_current_includes_latest_emotion_and_backfills_latest(
             (5, 1),  # 24h tool counts
             (0, 0),  # 1m log counts
             (0, 0),  # 24h log counts
-            (emotion_ts, "curious", 0.7, "0.2", "0.8"),  # latest emotion row
+            (emotion_ts, "curious", 0.7, 0.2, 0.8),  # latest emotion row
             None,  # latest relationship row
             *([None] * len(DESIRE_METRIC_KEYS)),
         ],
@@ -208,6 +208,8 @@ def test_current_latest_emotion_query_is_bounded_by_latest_ts(
     sql, params = emotion_queries[0]
     compact_sql = " ".join(sql.split())
     assert "WHERE ts <= %s" in compact_sql
+    assert "(numeric_metrics ->> 'valence')::double precision" in compact_sql
+    assert "(numeric_metrics ->> 'arousal')::double precision" in compact_sql
     assert params == (latest_ts,)
 
 

--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "0.2.9"
+version = "0.3.0"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.11"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "0.2.9"
+__version__ = "0.3.0"

--- a/ego-mcp/src/ego_mcp/_memory_queries.py
+++ b/ego-mcp/src/ego_mcp/_memory_queries.py
@@ -171,11 +171,12 @@ async def list_recent(
 ) -> list[Memory]:
     """List recent memories sorted by timestamp descending."""
     collection = store._ensure_connected()
-    if collection.count() == 0:
+    total = int(collection.count())
+    if total == 0:
         return []
 
     get_kwargs: dict[str, Any] = {
-        "limit": min(n * 3, collection.count()),
+        "limit": total,
         "include": ["documents", "metadatas"],
     }
     if category_filter:

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -53,6 +53,8 @@ EMOTION_DEFAULTS: dict[str, tuple[float, float, float]] = {
     "ashamed": (0.6, -0.7, 0.4),
     "bored": (0.3, -0.3, 0.1),
     "nostalgic": (0.5, 0.1, 0.3),
+    "contentment": (0.5, 0.5, 0.2),
+    "melancholy": (0.5, -0.4, 0.2),
     "surprised": (0.7, 0.1, 0.9),
 }
 _relative_time_override: Callable[[str, datetime | None], str] | None = None

--- a/ego-mcp/src/ego_mcp/episode.py
+++ b/ego-mcp/src/ego_mcp/episode.py
@@ -147,8 +147,12 @@ class EpisodeStore:
 
     async def list_episodes(self, limit: int = 20) -> list[Episode]:
         """List all episodes, newest first."""
+        total = int(self._collection.count())
+        if total == 0 or limit <= 0:
+            return []
+
         results = self._collection.get(
-            limit=limit,
+            limit=total,
             include=["documents", "metadatas"],
         )
         episodes = []
@@ -157,4 +161,4 @@ class EpisodeStore:
         ):
             episodes.append(Episode.from_metadata(eid, doc, meta))
         episodes.sort(key=lambda e: e.start_time, reverse=True)
-        return episodes
+        return episodes[:limit]

--- a/ego-mcp/tests/test_memory_queries.py
+++ b/ego-mcp/tests/test_memory_queries.py
@@ -1,0 +1,104 @@
+"""Focused tests for query helpers in ``_memory_queries``."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from ego_mcp import _memory_queries
+
+
+def _metadata(timestamp: str, *, category: str = "daily") -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "category": category,
+        "emotion": "neutral",
+        "intensity": 0.5,
+        "valence": 0.0,
+        "arousal": 0.5,
+    }
+
+
+class _FakeCollection:
+    def __init__(self, rows: list[tuple[str, str, dict[str, Any]]]) -> None:
+        self._rows = rows
+
+    def count(self) -> int:
+        return len(self._rows)
+
+    def get(
+        self,
+        *,
+        limit: int,
+        include: list[str],
+        where: dict[str, str] | None = None,
+    ) -> dict[str, list[Any]]:
+        assert include == ["documents", "metadatas"]
+        filtered = self._rows
+        if where is not None:
+            filtered = [
+                row for row in filtered if row[2].get("category") == where.get("category")
+            ]
+        selected = filtered[:limit]
+        ids = [row[0] for row in selected]
+        documents = [row[1] for row in selected]
+        metadatas = [row[2] for row in selected]
+        return {"ids": ids, "documents": documents, "metadatas": metadatas}
+
+
+class _FakeStore:
+    def __init__(self, rows: list[tuple[str, str, dict[str, Any]]]) -> None:
+        self._collection = _FakeCollection(rows)
+
+    def _ensure_connected(self) -> _FakeCollection:
+        return self._collection
+
+
+class TestListRecent:
+    @pytest.mark.asyncio
+    async def test_reads_full_collection_before_sorting(self) -> None:
+        rows = [
+            (
+                f"mem_{index:02d}",
+                f"memory {index}",
+                _metadata(f"2026-01-{index + 1:02d}T00:00:00+00:00"),
+            )
+            for index in range(10)
+        ]
+        store = _FakeStore(rows)
+
+        recent = await _memory_queries.list_recent(cast(Any, store), n=1)
+
+        assert [memory.id for memory in recent] == ["mem_09"]
+
+    @pytest.mark.asyncio
+    async def test_reads_full_filtered_collection_before_sorting(self) -> None:
+        filtered_rows = [
+            (
+                f"mem_i_{index:02d}",
+                f"introspection {index}",
+                _metadata(
+                    f"2026-02-{index + 1:02d}T00:00:00+00:00",
+                    category="introspection",
+                ),
+            )
+            for index in range(10)
+        ]
+        unfiltered_rows = [
+            (
+                f"mem_d_{index:02d}",
+                f"daily {index}",
+                _metadata(f"2026-01-{index + 1:02d}T00:00:00+00:00"),
+            )
+            for index in range(10)
+        ]
+        store = _FakeStore([*filtered_rows, *unfiltered_rows])
+
+        recent = await _memory_queries.list_recent(
+            cast(Any, store),
+            n=2,
+            category_filter="introspection",
+        )
+
+        assert [memory.id for memory in recent] == ["mem_i_09", "mem_i_08"]

--- a/ego-mcp/tests/test_server_surface_memory.py
+++ b/ego-mcp/tests/test_server_surface_memory.py
@@ -1,0 +1,19 @@
+"""Unit tests for remember surface emotion defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from ego_mcp._server_surface_memory import EMOTION_DEFAULTS
+from ego_mcp.types import Emotion
+
+
+def test_emotion_defaults_cover_all_enum_members() -> None:
+    expected = {emotion.value for emotion in Emotion}
+    missing = expected - set(EMOTION_DEFAULTS)
+    assert not missing
+
+
+def test_emotion_defaults_include_contentment_and_melancholy_values() -> None:
+    assert EMOTION_DEFAULTS["contentment"] == pytest.approx((0.5, 0.5, 0.2))
+    assert EMOTION_DEFAULTS["melancholy"] == pytest.approx((0.5, -0.4, 0.2))

--- a/ego-mcp/uv.lock
+++ b/ego-mcp/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "ego-mcp"
-version = "0.2.9"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- `list_recent()` / `list_episodes()` が ChromaDB の `get(limit=N)` の順序不定性により最新データを返さないバグを修正
- `EMOTION_DEFAULTS` に `"contentment"` / `"melancholy"` エントリを追加（v0.2.0 での Emotion enum 追加時の漏れ）
- Dashboard `sql_store.py` の valence/arousal クエリ型チェック統一
- Dashboard ログベースマイグレーションスクリプト追加（completion テレメトリの壊れた感情データを invocation ログから再構築）

## 背景

`remember(emotion="contentment", intensity=0.7)` 実行後の completion log に `emotion_primary: "neutral"`, `emotion_intensity: 0.5` が出力される問題を調査。全期間（2/26〜3/1）の completion テレメトリが 100% デフォルト値で壊れていることが判明。

## Test plan

- [x] ego-mcp: 301 tests passed
- [x] ego-mcp: isort / ruff / mypy 全通過
- [x] dashboard: 44 tests passed
- [x] dashboard: ruff / ruff format / mypy 全通過
- [x] frontend: lint / format:check / test (31 passed) / build 全通過
- [x] docker compose config OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)