### PR TITLE
Dashboard: Historyタブにneutral中心のEmotion trendグラフを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-ego-mcp のリリース履歴。
+ego-mcp / dashboard のリリース履歴。
+
+## [dashboard 0.2.1] - 2026-03-02
+
+### Added
+- Dashboard History タブに Emotion trend チャートを追加し、`neutral` を中央（0）として上側をポジティブ、下側をネガティブに時系列表示
+
+### Changed
+- バージョンアップ: dashboard 0.2.0→0.2.1, dashboard/frontend 0.1.0→0.2.1
 
 ## [0.3.0] - 2026-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ ego-mcp / dashboard のリリース履歴。
 ## [dashboard 0.2.1] - 2026-03-02
 
 ### Added
-- Dashboard History タブに Emotion trend チャートを追加し、`neutral` を中央（0）として上側をポジティブ、下側をネガティブに時系列表示
+- Dashboard History タブに Emotion trend チャートを追加し、`neutral` を中央（0）に固定した感情名（`curious`, `happy`, `sad` など）軸で時系列変化を表示
 
 ### Changed
+- Dashboard History タブのパネル順を調整し、`Intensity history` の直後に `Emotion trend` を配置（`Emotion distribution` と隣接）
 - バージョンアップ: dashboard 0.2.0→0.2.1, dashboard/frontend 0.1.0→0.2.1
 
 ## [0.3.0] - 2026-03-01

--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ego-dashboard-frontend",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ego-dashboard-frontend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.2.0",

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ego-dashboard-frontend",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/dashboard/frontend/src/components/history/emotion-timeline-chart.test.tsx
+++ b/dashboard/frontend/src/components/history/emotion-timeline-chart.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+
+import { EmotionTimelineChart } from '@/components/history/emotion-timeline-chart'
+import type { EmotionTrendPoint } from '@/types'
+
+describe('EmotionTimelineChart', () => {
+  it('renders card title', () => {
+    render(<EmotionTimelineChart points={[]} />)
+
+    expect(screen.getByText('Emotion trend')).toBeInTheDocument()
+  })
+
+  it('accepts timeline points with positive and negative values', () => {
+    const points: EmotionTrendPoint[] = [
+      { ts: '2026-01-01T12:01:00Z', value: 0.4, emotion_primary: 'curious' },
+      { ts: '2026-01-01T12:02:00Z', value: -0.6, emotion_primary: 'sad' },
+    ]
+
+    render(<EmotionTimelineChart points={points} />)
+
+    expect(screen.getByText('Emotion trend')).toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
+++ b/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
@@ -33,33 +33,35 @@ const config: ChartConfig = {
 
 export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
   const { formatTs } = useTimestampFormatter()
-  const { chartData, ticks, levelToEmotion, maxLevel } = useMemo(() => {
-    const axis = buildEmotionAxis(points)
-    const nextData = points.map((point) => {
-      const emotion =
-        typeof point.emotion_primary === 'string'
-          ? normalizeEmotion(point.emotion_primary)
-          : undefined
+  const { chartData, ticks, levelToEmotion, maxLevel, chartHeight } =
+    useMemo(() => {
+      const axis = buildEmotionAxis(points)
+      const nextData = points.map((point) => {
+        const emotion =
+          typeof point.emotion_primary === 'string'
+            ? normalizeEmotion(point.emotion_primary)
+            : undefined
+        return {
+          ...point,
+          emotion_primary: emotion,
+          emotion_level:
+            typeof emotion === 'string'
+              ? (axis.emotionToLevel.get(emotion) ?? null)
+              : null,
+        }
+      })
+      const maxAbsTick = axis.ticks.reduce(
+        (max, tick) => Math.max(max, Math.abs(tick)),
+        0,
+      )
       return {
-        ...point,
-        emotion_primary: emotion,
-        emotion_level:
-          typeof emotion === 'string'
-            ? (axis.emotionToLevel.get(emotion) ?? null)
-            : null,
+        chartData: nextData,
+        ticks: axis.ticks,
+        levelToEmotion: axis.levelToEmotion,
+        maxLevel: Math.max(1, maxAbsTick),
+        chartHeight: Math.max(320, axis.ticks.length * 18),
       }
-    })
-    const maxAbsTick = axis.ticks.reduce(
-      (max, tick) => Math.max(max, Math.abs(tick)),
-      0,
-    )
-    return {
-      chartData: nextData,
-      ticks: axis.ticks,
-      levelToEmotion: axis.levelToEmotion,
-      maxLevel: Math.max(1, maxAbsTick),
-    }
-  }, [points])
+    }, [points])
 
   const formatTooltipLabel = (
     label: unknown,
@@ -98,7 +100,11 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
         <CardTitle className="text-sm">Emotion trend</CardTitle>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={config} className="h-[260px] w-full">
+        <ChartContainer
+          config={config}
+          className="w-full"
+          style={{ height: `${chartHeight}px` }}
+        >
           <LineChart data={chartData}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="ts" hide />
@@ -106,6 +112,7 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
               domain={[-maxLevel, maxLevel]}
               ticks={ticks}
               allowDecimals={false}
+              interval={0}
               tickFormatter={(tickValue) =>
                 levelToEmotion.get(Number(tickValue)) ?? ''
               }

--- a/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
+++ b/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
@@ -16,6 +16,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   buildEmotionAxis,
+  emotionLabelForPoint,
   normalizeEmotion,
 } from '@/components/history/emotion-timeline-utils'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
@@ -73,6 +74,24 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
     return labelText
   }
 
+  const formatTooltipValue = (
+    _value: unknown,
+    _name: unknown,
+    item: {
+      payload?: { emotion_primary?: string; emotion_level?: number | null }
+    },
+  ) => {
+    const emotion = emotionLabelForPoint(item.payload, levelToEmotion)
+    return (
+      <div className="flex w-full items-center justify-between gap-2 leading-none">
+        <span className="text-muted-foreground">emotion</span>
+        <span className="text-foreground font-mono font-medium tabular-nums">
+          {emotion}
+        </span>
+      </div>
+    )
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -94,7 +113,10 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
             <ReferenceLine y={0} stroke="#ccc" strokeDasharray="4 4" />
             <ChartTooltip
               content={
-                <ChartTooltipContent labelFormatter={formatTooltipLabel} />
+                <ChartTooltipContent
+                  labelFormatter={formatTooltipLabel}
+                  formatter={formatTooltipValue}
+                />
               }
             />
             <Line

--- a/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
+++ b/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
@@ -1,0 +1,84 @@
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
+import type { EmotionTrendPoint } from '@/types'
+
+type EmotionTimelineChartProps = {
+  points: EmotionTrendPoint[]
+}
+
+const config: ChartConfig = {
+  value: { label: 'emotion polarity', color: 'var(--color-chart-5)' },
+}
+
+const formatPolarityTick = (value: number) => {
+  if (value === 1) return 'positive'
+  if (value === 0) return 'neutral'
+  if (value === -1) return 'negative'
+  return String(value)
+}
+
+export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
+  const { formatTs } = useTimestampFormatter()
+
+  const formatTooltipLabel = (
+    label: unknown,
+    payload: Array<{ payload?: { emotion_primary?: string } }> | undefined,
+  ) => {
+    const labelText =
+      typeof label === 'string' ? formatTs(label) : String(label ?? '')
+    const emotion = payload?.[0]?.payload?.emotion_primary
+    if (typeof emotion === 'string' && emotion.length > 0) {
+      return `${labelText} — ${emotion}`
+    }
+    return labelText
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Emotion trend</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={config} className="h-[260px] w-full">
+          <LineChart data={points}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="ts" hide />
+            <YAxis
+              domain={[-1, 1]}
+              ticks={[-1, 0, 1]}
+              tickFormatter={formatPolarityTick}
+            />
+            <ReferenceLine y={0} stroke="#ccc" strokeDasharray="4 4" />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent labelFormatter={formatTooltipLabel} />
+              }
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke="var(--color-value)"
+              dot={false}
+              connectNulls
+            />
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
+++ b/dashboard/frontend/src/components/history/emotion-timeline-chart.tsx
@@ -14,26 +14,51 @@ import {
   type ChartConfig,
 } from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  buildEmotionAxis,
+  normalizeEmotion,
+} from '@/components/history/emotion-timeline-utils'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { EmotionTrendPoint } from '@/types'
+import { useMemo } from 'react'
 
 type EmotionTimelineChartProps = {
   points: EmotionTrendPoint[]
 }
 
 const config: ChartConfig = {
-  value: { label: 'emotion polarity', color: 'var(--color-chart-5)' },
-}
-
-const formatPolarityTick = (value: number) => {
-  if (value === 1) return 'positive'
-  if (value === 0) return 'neutral'
-  if (value === -1) return 'negative'
-  return String(value)
+  emotion_level: { label: 'emotion', color: 'var(--color-chart-5)' },
 }
 
 export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
   const { formatTs } = useTimestampFormatter()
+  const { chartData, ticks, levelToEmotion, maxLevel } = useMemo(() => {
+    const axis = buildEmotionAxis(points)
+    const nextData = points.map((point) => {
+      const emotion =
+        typeof point.emotion_primary === 'string'
+          ? normalizeEmotion(point.emotion_primary)
+          : undefined
+      return {
+        ...point,
+        emotion_primary: emotion,
+        emotion_level:
+          typeof emotion === 'string'
+            ? (axis.emotionToLevel.get(emotion) ?? null)
+            : null,
+      }
+    })
+    const maxAbsTick = axis.ticks.reduce(
+      (max, tick) => Math.max(max, Math.abs(tick)),
+      0,
+    )
+    return {
+      chartData: nextData,
+      ticks: axis.ticks,
+      levelToEmotion: axis.levelToEmotion,
+      maxLevel: Math.max(1, maxAbsTick),
+    }
+  }, [points])
 
   const formatTooltipLabel = (
     label: unknown,
@@ -55,13 +80,16 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
       </CardHeader>
       <CardContent>
         <ChartContainer config={config} className="h-[260px] w-full">
-          <LineChart data={points}>
+          <LineChart data={chartData}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="ts" hide />
             <YAxis
-              domain={[-1, 1]}
-              ticks={[-1, 0, 1]}
-              tickFormatter={formatPolarityTick}
+              domain={[-maxLevel, maxLevel]}
+              ticks={ticks}
+              allowDecimals={false}
+              tickFormatter={(tickValue) =>
+                levelToEmotion.get(Number(tickValue)) ?? ''
+              }
             />
             <ReferenceLine y={0} stroke="#ccc" strokeDasharray="4 4" />
             <ChartTooltip
@@ -71,10 +99,9 @@ export const EmotionTimelineChart = ({ points }: EmotionTimelineChartProps) => {
             />
             <Line
               type="monotone"
-              dataKey="value"
-              stroke="var(--color-value)"
+              dataKey="emotion_level"
+              stroke="var(--color-emotion_level)"
               dot={false}
-              connectNulls
             />
           </LineChart>
         </ChartContainer>

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
@@ -5,7 +5,7 @@ import {
 import type { EmotionTrendPoint } from '@/types'
 
 describe('buildEmotionAxis', () => {
-  it('keeps neutral at center and arranges positive/negative emotions around it', () => {
+  it('keeps neutral at center and includes the full known emotion set', () => {
     const points: EmotionTrendPoint[] = [
       { ts: '2026-01-01T12:00:00Z', value: 0.3, emotion_primary: 'curious' },
       { ts: '2026-01-01T12:01:00Z', value: 0.7, emotion_primary: 'happy' },
@@ -16,11 +16,27 @@ describe('buildEmotionAxis', () => {
     const axis = buildEmotionAxis(points)
 
     expect(axis.emotionToLevel.get('neutral')).toBe(0)
-    expect(axis.emotionToLevel.get('curious')).toBe(1)
-    expect(axis.emotionToLevel.get('happy')).toBe(2)
-    expect(axis.emotionToLevel.get('sad')).toBe(-1)
-    expect(axis.emotionToLevel.get('anxious')).toBe(-2)
-    expect(axis.ticks).toEqual([-2, -1, 0, 1, 2])
+    expect(axis.emotionToLevel.get('happy')).toBeGreaterThan(0)
+    expect(axis.emotionToLevel.get('curious')).toBeGreaterThan(0)
+    expect(axis.emotionToLevel.get('sad')).toBeLessThan(0)
+    expect(axis.emotionToLevel.get('anxious')).toBeLessThan(0)
+    expect(axis.emotionToLevel.get('surprised')).toBeGreaterThan(0)
+    expect(axis.emotionToLevel.get('melancholy')).toBeLessThan(0)
+    expect(axis.ticks).toContain(0)
+    expect(axis.ticks.length).toBe(axis.emotionToLevel.size)
+    expect(axis.ticks.length).toBeGreaterThanOrEqual(30)
+  })
+
+  it('adds unknown observed emotions to the fixed legend', () => {
+    const points: EmotionTrendPoint[] = [
+      { ts: '2026-01-01T12:10:00Z', value: 0.6, emotion_primary: 'euphoric' },
+      { ts: '2026-01-01T12:11:00Z', value: -0.7, emotion_primary: 'gloomy' },
+    ]
+
+    const axis = buildEmotionAxis(points)
+
+    expect(axis.emotionToLevel.get('euphoric')).toBeGreaterThan(0)
+    expect(axis.emotionToLevel.get('gloomy')).toBeLessThan(0)
   })
 
   it('returns emotion label for tooltip from primary emotion first', () => {

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
@@ -1,0 +1,22 @@
+import { buildEmotionAxis } from '@/components/history/emotion-timeline-utils'
+import type { EmotionTrendPoint } from '@/types'
+
+describe('buildEmotionAxis', () => {
+  it('keeps neutral at center and arranges positive/negative emotions around it', () => {
+    const points: EmotionTrendPoint[] = [
+      { ts: '2026-01-01T12:00:00Z', value: 0.3, emotion_primary: 'curious' },
+      { ts: '2026-01-01T12:01:00Z', value: 0.7, emotion_primary: 'happy' },
+      { ts: '2026-01-01T12:02:00Z', value: -0.6, emotion_primary: 'sad' },
+      { ts: '2026-01-01T12:03:00Z', value: -0.8, emotion_primary: 'anxious' },
+    ]
+
+    const axis = buildEmotionAxis(points)
+
+    expect(axis.emotionToLevel.get('neutral')).toBe(0)
+    expect(axis.emotionToLevel.get('curious')).toBe(1)
+    expect(axis.emotionToLevel.get('happy')).toBe(2)
+    expect(axis.emotionToLevel.get('sad')).toBe(-1)
+    expect(axis.emotionToLevel.get('anxious')).toBe(-2)
+    expect(axis.ticks).toEqual([-2, -1, 0, 1, 2])
+  })
+})

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.test.ts
@@ -1,4 +1,7 @@
-import { buildEmotionAxis } from '@/components/history/emotion-timeline-utils'
+import {
+  buildEmotionAxis,
+  emotionLabelForPoint,
+} from '@/components/history/emotion-timeline-utils'
 import type { EmotionTrendPoint } from '@/types'
 
 describe('buildEmotionAxis', () => {
@@ -18,5 +21,24 @@ describe('buildEmotionAxis', () => {
     expect(axis.emotionToLevel.get('sad')).toBe(-1)
     expect(axis.emotionToLevel.get('anxious')).toBe(-2)
     expect(axis.ticks).toEqual([-2, -1, 0, 1, 2])
+  })
+
+  it('returns emotion label for tooltip from primary emotion first', () => {
+    const levelToEmotion = new Map<number, string>([
+      [-1, 'sad'],
+      [0, 'neutral'],
+      [1, 'happy'],
+    ])
+
+    expect(
+      emotionLabelForPoint(
+        { emotion_primary: 'Curious', emotion_level: -1 },
+        levelToEmotion,
+      ),
+    ).toBe('curious')
+    expect(emotionLabelForPoint({ emotion_level: 1 }, levelToEmotion)).toBe(
+      'happy',
+    )
+    expect(emotionLabelForPoint(undefined, levelToEmotion)).toBe('unknown')
   })
 })

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
@@ -11,6 +11,11 @@ export type EmotionAxis = {
   ticks: number[]
 }
 
+type EmotionPointLike = {
+  emotion_primary?: string | null
+  emotion_level?: number | null
+}
+
 const FALLBACK_EMOTION_VALENCE: Record<string, number> = {
   happy: 0.6,
   excited: 0.7,
@@ -45,6 +50,22 @@ const FALLBACK_EMOTION_VALENCE: Record<string, number> = {
 }
 
 export const normalizeEmotion = (value: string) => value.trim().toLowerCase()
+
+export const emotionLabelForPoint = (
+  point: EmotionPointLike | undefined,
+  levelToEmotion: Map<number, string>,
+) => {
+  if (
+    typeof point?.emotion_primary === 'string' &&
+    point.emotion_primary.length > 0
+  ) {
+    return normalizeEmotion(point.emotion_primary)
+  }
+  if (typeof point?.emotion_level === 'number') {
+    return levelToEmotion.get(point.emotion_level) ?? 'unknown'
+  }
+  return 'unknown'
+}
 
 const valenceFor = (emotion: string, observed: number | undefined) => {
   if (Number.isFinite(observed)) return observed as number

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
@@ -49,6 +49,10 @@ const FALLBACK_EMOTION_VALENCE: Record<string, number> = {
   surprised: 0.1,
 }
 
+const KNOWN_EMOTION_SCORES = Object.entries(FALLBACK_EMOTION_VALENCE)
+  .filter(([emotion]) => emotion !== 'neutral')
+  .map(([emotion, score]) => ({ emotion, score }))
+
 export const normalizeEmotion = (value: string) => value.trim().toLowerCase()
 
 export const emotionLabelForPoint = (
@@ -74,35 +78,21 @@ const valenceFor = (emotion: string, observed: number | undefined) => {
 
 export const buildEmotionAxis = (points: EmotionTrendPoint[]): EmotionAxis => {
   const stats = new Map<string, EmotionStat>()
-
   for (const point of points) {
     if (typeof point.emotion_primary !== 'string') continue
     const emotion = normalizeEmotion(point.emotion_primary)
     if (emotion.length === 0) continue
-
+    if (FALLBACK_EMOTION_VALENCE[emotion] !== undefined) continue
     const current = stats.get(emotion) ?? { sum: 0, count: 0 }
     current.sum += valenceFor(emotion, point.value)
     current.count += 1
     stats.set(emotion, current)
   }
 
-  stats.set('neutral', stats.get('neutral') ?? { sum: 0, count: 1 })
-
-  const positives: Array<{ emotion: string; score: number }> = []
-  const negatives: Array<{ emotion: string; score: number }> = []
-
-  for (const [emotion, stat] of stats) {
-    if (emotion === 'neutral') continue
-    const score =
-      stat.count > 0
-        ? stat.sum / stat.count
-        : (FALLBACK_EMOTION_VALENCE[emotion] ?? 0)
-    if (score >= 0) {
-      positives.push({ emotion, score })
-      continue
-    }
-    negatives.push({ emotion, score })
-  }
+  const positives: Array<{ emotion: string; score: number }> =
+    KNOWN_EMOTION_SCORES.filter((row) => row.score >= 0)
+  const negatives: Array<{ emotion: string; score: number }> =
+    KNOWN_EMOTION_SCORES.filter((row) => row.score < 0)
 
   positives.sort(
     (lhs, rhs) =>
@@ -113,15 +103,40 @@ export const buildEmotionAxis = (points: EmotionTrendPoint[]): EmotionAxis => {
       rhs.score - lhs.score || lhs.emotion.localeCompare(rhs.emotion),
   )
 
+  const unknownPositives: Array<{ emotion: string; score: number }> = []
+  const unknownNegatives: Array<{ emotion: string; score: number }> = []
+  for (const [emotion, stat] of stats) {
+    const score = stat.sum / stat.count
+    if (score >= 0) {
+      unknownPositives.push({ emotion, score })
+      continue
+    }
+    unknownNegatives.push({ emotion, score })
+  }
+  unknownPositives.sort(
+    (lhs, rhs) =>
+      lhs.score - rhs.score || lhs.emotion.localeCompare(rhs.emotion),
+  )
+  unknownNegatives.sort(
+    (lhs, rhs) =>
+      rhs.score - lhs.score || lhs.emotion.localeCompare(rhs.emotion),
+  )
+
   const emotionToLevel = new Map<string, number>()
   emotionToLevel.set('neutral', 0)
 
   positives.forEach((entry, index) => {
     emotionToLevel.set(entry.emotion, index + 1)
   })
+  unknownPositives.forEach((entry, index) => {
+    emotionToLevel.set(entry.emotion, positives.length + index + 1)
+  })
 
   negatives.forEach((entry, index) => {
     emotionToLevel.set(entry.emotion, -(index + 1))
+  })
+  unknownNegatives.forEach((entry, index) => {
+    emotionToLevel.set(entry.emotion, -(negatives.length + index + 1))
   })
 
   const levelToEmotion = new Map<number, string>()

--- a/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
+++ b/dashboard/frontend/src/components/history/emotion-timeline-utils.ts
@@ -1,0 +1,114 @@
+import type { EmotionTrendPoint } from '@/types'
+
+type EmotionStat = {
+  sum: number
+  count: number
+}
+
+export type EmotionAxis = {
+  emotionToLevel: Map<string, number>
+  levelToEmotion: Map<number, string>
+  ticks: number[]
+}
+
+const FALLBACK_EMOTION_VALENCE: Record<string, number> = {
+  happy: 0.6,
+  excited: 0.7,
+  calm: 0.3,
+  neutral: 0,
+  curious: 0.3,
+  contemplative: 0.1,
+  thoughtful: 0.1,
+  grateful: 0.7,
+  vulnerable: -0.3,
+  content: 0.5,
+  fulfilled: 0.6,
+  touched: 0.5,
+  moved: 0.5,
+  concerned: -0.3,
+  hopeful: 0.4,
+  peaceful: 0.4,
+  love: 0.8,
+  warm: 0.5,
+  sad: -0.6,
+  anxious: -0.6,
+  angry: -0.7,
+  frustrated: -0.5,
+  lonely: -0.6,
+  afraid: -0.8,
+  ashamed: -0.7,
+  bored: -0.3,
+  nostalgic: 0.1,
+  contentment: 0.5,
+  melancholy: -0.4,
+  surprised: 0.1,
+}
+
+export const normalizeEmotion = (value: string) => value.trim().toLowerCase()
+
+const valenceFor = (emotion: string, observed: number | undefined) => {
+  if (Number.isFinite(observed)) return observed as number
+  return FALLBACK_EMOTION_VALENCE[emotion] ?? 0
+}
+
+export const buildEmotionAxis = (points: EmotionTrendPoint[]): EmotionAxis => {
+  const stats = new Map<string, EmotionStat>()
+
+  for (const point of points) {
+    if (typeof point.emotion_primary !== 'string') continue
+    const emotion = normalizeEmotion(point.emotion_primary)
+    if (emotion.length === 0) continue
+
+    const current = stats.get(emotion) ?? { sum: 0, count: 0 }
+    current.sum += valenceFor(emotion, point.value)
+    current.count += 1
+    stats.set(emotion, current)
+  }
+
+  stats.set('neutral', stats.get('neutral') ?? { sum: 0, count: 1 })
+
+  const positives: Array<{ emotion: string; score: number }> = []
+  const negatives: Array<{ emotion: string; score: number }> = []
+
+  for (const [emotion, stat] of stats) {
+    if (emotion === 'neutral') continue
+    const score =
+      stat.count > 0
+        ? stat.sum / stat.count
+        : (FALLBACK_EMOTION_VALENCE[emotion] ?? 0)
+    if (score >= 0) {
+      positives.push({ emotion, score })
+      continue
+    }
+    negatives.push({ emotion, score })
+  }
+
+  positives.sort(
+    (lhs, rhs) =>
+      lhs.score - rhs.score || lhs.emotion.localeCompare(rhs.emotion),
+  )
+  negatives.sort(
+    (lhs, rhs) =>
+      rhs.score - lhs.score || lhs.emotion.localeCompare(rhs.emotion),
+  )
+
+  const emotionToLevel = new Map<string, number>()
+  emotionToLevel.set('neutral', 0)
+
+  positives.forEach((entry, index) => {
+    emotionToLevel.set(entry.emotion, index + 1)
+  })
+
+  negatives.forEach((entry, index) => {
+    emotionToLevel.set(entry.emotion, -(index + 1))
+  })
+
+  const levelToEmotion = new Map<number, string>()
+  for (const [emotion, level] of emotionToLevel) {
+    levelToEmotion.set(level, emotion)
+  }
+
+  const ticks = Array.from(levelToEmotion.keys()).sort((lhs, rhs) => lhs - rhs)
+
+  return { emotionToLevel, levelToEmotion, ticks }
+}

--- a/dashboard/frontend/src/components/history/history-tab.tsx
+++ b/dashboard/frontend/src/components/history/history-tab.tsx
@@ -32,8 +32,8 @@ export const HistoryTab = ({ range, preset }: HistoryTabProps) => {
         toolSeriesKeys={toolSeriesKeys}
         timeline={timeline}
       />
-      <EmotionTimelineChart points={emotionTrend} />
       <IntensityChart intensity={intensity} />
+      <EmotionTimelineChart points={emotionTrend} />
       <EmotionDistributionChart heatmapData={emotionHeatmap} />
       <ValenceArousalChart valence={valence} arousal={arousal} />
       <DesireHistoryChart desireChartData={desireChartData} />

--- a/dashboard/frontend/src/components/history/history-tab.tsx
+++ b/dashboard/frontend/src/components/history/history-tab.tsx
@@ -1,5 +1,6 @@
 import { DesireHistoryChart } from '@/components/history/desire-history-chart'
 import { EmotionDistributionChart } from '@/components/history/emotion-distribution-chart'
+import { EmotionTimelineChart } from '@/components/history/emotion-timeline-chart'
 import { IntensityChart } from '@/components/history/intensity-chart'
 import { ToolUsageChart } from '@/components/history/tool-usage-chart'
 import { ValenceArousalChart } from '@/components/history/valence-arousal-chart'
@@ -18,6 +19,7 @@ export const HistoryTab = ({ range, preset }: HistoryTabProps) => {
     timeline,
     valence,
     arousal,
+    emotionTrend,
     emotionHeatmap,
     toolSeriesKeys,
     desireChartData,
@@ -30,6 +32,7 @@ export const HistoryTab = ({ range, preset }: HistoryTabProps) => {
         toolSeriesKeys={toolSeriesKeys}
         timeline={timeline}
       />
+      <EmotionTimelineChart points={emotionTrend} />
       <IntensityChart intensity={intensity} />
       <EmotionDistributionChart heatmapData={emotionHeatmap} />
       <ValenceArousalChart valence={valence} arousal={arousal} />

--- a/dashboard/frontend/src/hooks/use-history-data.test.tsx
+++ b/dashboard/frontend/src/hooks/use-history-data.test.tsx
@@ -19,7 +19,7 @@ describe('useHistoryData', () => {
     vi.restoreAllMocks()
   })
 
-  it('merges intensity points with emotion timeline and returns emotion heatmap', async () => {
+  it('builds emotion trend with neutral-centered valence and merged emotion labels', async () => {
     const range = {
       from: '2026-01-01T12:00:00Z',
       to: '2026-01-01T12:10:00Z',
@@ -30,10 +30,16 @@ describe('useHistoryData', () => {
     ])
     vi.mocked(api.fetchUsage).mockResolvedValue([])
     vi.mocked(api.fetchTimeline).mockResolvedValue([])
-    vi.mocked(api.fetchValence).mockResolvedValue([])
+    vi.mocked(api.fetchValence).mockResolvedValue([
+      { ts: '2026-01-01T12:01:00Z', value: 0.4 },
+      { ts: '2026-01-01T12:02:00Z', value: -0.6 },
+      { ts: '2026-01-01T12:03:00Z', value: 1.2 },
+    ])
     vi.mocked(api.fetchArousal).mockResolvedValue([])
     vi.mocked(api.fetchStringTimeline).mockResolvedValue([
+      { ts: '2026-01-01T12:00:30Z', value: 'neutral' },
       { ts: '2026-01-01T12:01:00Z', value: 'curious' },
+      { ts: '2026-01-01T12:02:00Z', value: 'sad' },
     ])
     vi.mocked(api.fetchStringHeatmap).mockResolvedValue([
       { ts: '2026-01-01T12:00:00Z', counts: { curious: 2 } },
@@ -52,6 +58,11 @@ describe('useHistoryData', () => {
     ).toBe('curious')
     expect(result.current.emotionHeatmap).toEqual([
       { ts: '2026-01-01T12:00:00Z', counts: { curious: 2 } },
+    ])
+    expect(result.current.emotionTrend).toEqual([
+      { ts: '2026-01-01T12:01:00Z', value: 0.4, emotion_primary: 'curious' },
+      { ts: '2026-01-01T12:02:00Z', value: -0.6, emotion_primary: 'sad' },
+      { ts: '2026-01-01T12:03:00Z', value: 1, emotion_primary: 'sad' },
     ])
     expect(api.fetchStringTimeline).toHaveBeenCalledWith(
       'emotion_primary',

--- a/dashboard/frontend/src/hooks/use-history-data.test.tsx
+++ b/dashboard/frontend/src/hooks/use-history-data.test.tsx
@@ -19,7 +19,7 @@ describe('useHistoryData', () => {
     vi.restoreAllMocks()
   })
 
-  it('builds emotion trend with neutral-centered valence and merged emotion labels', async () => {
+  it('builds emotion trend from emotion timeline with latest valence context', async () => {
     const range = {
       from: '2026-01-01T12:00:00Z',
       to: '2026-01-01T12:10:00Z',
@@ -60,9 +60,9 @@ describe('useHistoryData', () => {
       { ts: '2026-01-01T12:00:00Z', counts: { curious: 2 } },
     ])
     expect(result.current.emotionTrend).toEqual([
+      { ts: '2026-01-01T12:00:30Z', value: 0, emotion_primary: 'neutral' },
       { ts: '2026-01-01T12:01:00Z', value: 0.4, emotion_primary: 'curious' },
       { ts: '2026-01-01T12:02:00Z', value: -0.6, emotion_primary: 'sad' },
-      { ts: '2026-01-01T12:03:00Z', value: 1, emotion_primary: 'sad' },
     ])
     expect(api.fetchStringTimeline).toHaveBeenCalledWith(
       'emotion_primary',

--- a/dashboard/frontend/src/hooks/use-history-data.ts
+++ b/dashboard/frontend/src/hooks/use-history-data.ts
@@ -13,6 +13,7 @@ import {
 import { DESIRE_METRIC_KEYS, type DesireMetricKey } from '@/constants'
 import type {
   DateRange,
+  EmotionTrendPoint,
   HeatmapPoint,
   IntensityPoint,
   SeriesPoint,
@@ -48,6 +49,7 @@ export const useHistoryData = (
   const [timeline, setTimeline] = useState<StringPoint[]>([])
   const [valence, setValence] = useState<SeriesPoint[]>([])
   const [arousal, setArousal] = useState<SeriesPoint[]>([])
+  const [emotionTrend, setEmotionTrend] = useState<EmotionTrendPoint[]>([])
   const [emotionHeatmap, setEmotionHeatmap] = useState<HeatmapPoint[]>([])
   const [desireMetrics, setDesireMetrics] = useState<DesireMetricSeriesMap>(
     makeEmptyDesireMetricSeriesMap,
@@ -75,6 +77,29 @@ export const useHistoryData = (
       const emotionByTimestamp = new Map(
         emotionTimeline.map((point) => [point.ts, point.value]),
       )
+      const valenceSorted = [...v].sort((lhs, rhs) =>
+        lhs.ts.localeCompare(rhs.ts),
+      )
+      const emotionTimelineSorted = [...emotionTimeline].sort((lhs, rhs) =>
+        lhs.ts.localeCompare(rhs.ts),
+      )
+      const nextEmotionTrend: EmotionTrendPoint[] = []
+      let emotionCursor = 0
+      let currentEmotion: string | undefined
+      for (const point of valenceSorted) {
+        while (
+          emotionCursor < emotionTimelineSorted.length &&
+          emotionTimelineSorted[emotionCursor].ts <= point.ts
+        ) {
+          currentEmotion = emotionTimelineSorted[emotionCursor].value
+          emotionCursor += 1
+        }
+        nextEmotionTrend.push({
+          ts: point.ts,
+          value: Math.max(-1, Math.min(1, point.value)),
+          emotion_primary: currentEmotion,
+        })
+      }
       setIntensity(
         i.map((point) => ({
           ...point,
@@ -85,6 +110,7 @@ export const useHistoryData = (
       setTimeline(t)
       setValence(v)
       setArousal(a)
+      setEmotionTrend(nextEmotionTrend)
       setEmotionHeatmap(heatmap)
       setDesireMetrics({
         information_hunger: desireSeries[0] ?? [],
@@ -141,6 +167,7 @@ export const useHistoryData = (
     timeline,
     valence,
     arousal,
+    emotionTrend,
     emotionHeatmap,
     desireMetrics,
     toolSeriesKeys,

--- a/dashboard/frontend/src/hooks/use-history-data.ts
+++ b/dashboard/frontend/src/hooks/use-history-data.ts
@@ -84,20 +84,23 @@ export const useHistoryData = (
         lhs.ts.localeCompare(rhs.ts),
       )
       const nextEmotionTrend: EmotionTrendPoint[] = []
-      let emotionCursor = 0
-      let currentEmotion: string | undefined
-      for (const point of valenceSorted) {
+      let valenceCursor = 0
+      let currentValence = 0
+      for (const point of emotionTimelineSorted) {
         while (
-          emotionCursor < emotionTimelineSorted.length &&
-          emotionTimelineSorted[emotionCursor].ts <= point.ts
+          valenceCursor < valenceSorted.length &&
+          valenceSorted[valenceCursor].ts <= point.ts
         ) {
-          currentEmotion = emotionTimelineSorted[emotionCursor].value
-          emotionCursor += 1
+          currentValence = Math.max(
+            -1,
+            Math.min(1, valenceSorted[valenceCursor].value),
+          )
+          valenceCursor += 1
         }
         nextEmotionTrend.push({
           ts: point.ts,
-          value: Math.max(-1, Math.min(1, point.value)),
-          emotion_primary: currentEmotion,
+          value: currentValence,
+          emotion_primary: point.value,
         })
       }
       setIntensity(

--- a/dashboard/frontend/src/types.ts
+++ b/dashboard/frontend/src/types.ts
@@ -45,6 +45,7 @@ export type DateRange = {
 
 export type SeriesPoint = { ts: string; value: number }
 export type IntensityPoint = SeriesPoint & { emotion_primary?: string }
+export type EmotionTrendPoint = SeriesPoint & { emotion_primary?: string }
 export type UsagePoint = { ts: string; [key: string]: number | string }
 export type StringPoint = { ts: string; value: string }
 export type HeatmapPoint = { ts: string; counts: Record<string, number> }

--- a/dashboard/pyproject.toml
+++ b/dashboard/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ego-dashboard"
-version = "0.2.0"
+version = "0.2.1"
 description = "Dashboard backend for ego-mcp telemetry"
 requires-python = ">=3.11"
 dependencies = [

--- a/dashboard/uv.lock
+++ b/dashboard/uv.lock
@@ -74,7 +74,7 @@ wheels = [
 
 [[package]]
 name = "ego-dashboard"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Historyタブに Emotion trend チャートを追加
- Y軸を感情ラベル（curious / happy / sad など）で表示し、neutral を中央(0)に固定
- positive 系感情を上側、negative 系感情を下側に配置
- useHistoryData を更新し、emotion timeline を基準に emotionTrend を生成
- パネル順を調整し、Intensity history の直後に Emotion trend を配置（Emotion distribution と隣接）
- テスト追加（hook + chart + axis utility）
- CHANGELOG追記とバージョン更新（dashboard 0.2.0 -> 0.2.1, dashboard/frontend 0.1.0 -> 0.2.1）

## Testing
- cd dashboard && uv sync --group dev
- cd dashboard && uv run pytest -v
- cd dashboard && uv run ruff check src tests
- cd dashboard && uv run ruff format --check src tests
- cd dashboard && uv run mypy src tests
- cd dashboard/frontend && npm run lint
- cd dashboard/frontend && npm run format:check
- cd dashboard/frontend && npm run test
- cd dashboard/frontend && npm run build
- cd dashboard && docker compose config
