### PR TITLE
Add env-configurable application timezone (EGO_MCP_TIMEZONE) and timezone utilities

### DIFF
--- a/ego-mcp/src/ego_mcp/_memory_scoring.py
+++ b/ego-mcp/src/ego_mcp/_memory_scoring.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime
 
+from ego_mcp import timezone_utils
 from ego_mcp.types import Memory
 
 EMOTION_BOOST_MAP: dict[str, float] = {
@@ -30,12 +31,12 @@ def calculate_time_decay(
 ) -> float:
     """Exponential time decay. Returns 0.0 (forgotten) to 1.0 (fresh)."""
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
 
     try:
         memory_time = datetime.fromisoformat(timestamp)
         if memory_time.tzinfo is None:
-            memory_time = memory_time.replace(tzinfo=timezone.utc)
+            memory_time = memory_time.replace(tzinfo=timezone_utils.app_timezone())
     except ValueError:
         return 1.0
 

--- a/ego-mcp/src/ego_mcp/_server_backend_handlers.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_handlers.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable
 
+from ego_mcp import timezone_utils
 from ego_mcp._server_context import _relationship_store
 from ego_mcp._server_emotion_formatting import (
     _format_month_emotion_layer,
@@ -186,7 +187,7 @@ async def _handle_emotion_trend(memory: MemoryStore) -> str:
         )
         return compose_response(data, SCAFFOLD_EMOTION_TREND)
 
-    now = datetime.now(timezone.utc)
+    now = timezone_utils.now()
     sections = [_format_recent_emotion_layer(memories, now=now)]
     if total >= 15:
         sections.append(_format_week_emotion_layer(memories, now=now))

--- a/ego-mcp/src/ego_mcp/_server_context.py
+++ b/ego-mcp/src/ego_mcp/_server_context.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import math
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
+from ego_mcp import timezone_utils
 from ego_mcp.config import EgoConfig
 from ego_mcp.memory import MemoryStore
 from ego_mcp.relationship import RelationshipStore
@@ -110,7 +111,7 @@ async def _summarize_conversation_tendency(
     if not pool:
         return "no recent conversation memories", "unknown tone", [], []
 
-    now = datetime.now(timezone.utc)
+    now = timezone_utils.now()
     window_start = now - timedelta(days=7)
 
     last_7d = 0
@@ -121,7 +122,7 @@ async def _summarize_conversation_tendency(
         try:
             ts = datetime.fromisoformat(mem.timestamp)
             if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
+                ts = ts.replace(tzinfo=timezone_utils.app_timezone())
             if ts >= window_start:
                 last_7d += 1
         except ValueError:

--- a/ego-mcp/src/ego_mcp/_server_emotion_formatting.py
+++ b/ego-mcp/src/ego_mcp/_server_emotion_formatting.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Callable
 
+from ego_mcp import timezone_utils
 from ego_mcp.memory import calculate_time_decay, count_emotions_weighted
 from ego_mcp.types import Memory, MemorySearchResult
 
@@ -59,15 +60,15 @@ def _truncate_for_log(text: str, limit: int = 1200) -> tuple[str, bool]:
 def _relative_time(timestamp: str, now: datetime | None = None) -> str:
     """Format an ISO8601 timestamp as compact relative time (e.g. 2d ago)."""
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
     try:
         dt = datetime.fromisoformat(timestamp)
     except ValueError:
         return "unknown time"
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=timezone_utils.app_timezone())
     if now.tzinfo is None:
-        now = now.replace(tzinfo=timezone.utc)
+        now = now.replace(tzinfo=timezone_utils.app_timezone())
 
     seconds = max(0, int((now - dt).total_seconds()))
     if seconds < 60:
@@ -94,7 +95,7 @@ def _format_recall_entry(
 ) -> str:
     """Render a single recall result in the compact two-line format."""
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
     memory = result.memory
     age = _call_relative_time(memory.timestamp, now=now)
     content = _truncate_for_quote(memory.content, limit=70)
@@ -150,7 +151,7 @@ def _parse_iso_datetime(timestamp: str) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=timezone_utils.app_timezone())
     return parsed
 
 
@@ -159,7 +160,7 @@ def _memories_within_days(
 ) -> list[Memory]:
     """Return memories whose timestamps fall within the last `days` days."""
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
     window_start = now - timedelta(days=days)
     selected: list[Memory] = []
     for memory in memories:

--- a/ego-mcp/src/ego_mcp/_server_surface_core.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_core.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
+from ego_mcp import timezone_utils
 from ego_mcp._server_context import (
     _derive_desire_modulation,
     _fading_important_questions,
@@ -317,7 +317,7 @@ async def _handle_consider_them(
         sensitive_topics,
     ) = await _summarize_conversation_tendency(memory, person)
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = timezone_utils.now().isoformat()
     if dominant_tone != "unknown tone":
         store.add_interaction(person, now_iso, dominant_tone)
     rel = store.apply_tom_feedback(

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable
 
+from ego_mcp import timezone_utils
 from ego_mcp._server_context import (
     _find_related_forgotten_questions,
     _relationship_store,
@@ -313,7 +314,7 @@ async def _handle_recall(
         data = "No related memories found."
     else:
         lines = [f"{len(results)} of ~{total_count} memories (showing top matches):"]
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
         for i, result in enumerate(results, 1):
             lines.append(_format_recall_entry(i, result, now=now))
         data = "\n".join(lines)

--- a/ego-mcp/src/ego_mcp/config.py
+++ b/ego-mcp/src/ego_mcp/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 _DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini-embedding-001",
@@ -33,6 +34,7 @@ class EgoConfig:
         EGO_MCP_DATA_DIR: Data directory (default: ~/.ego-mcp/data)
         EGO_MCP_COMPANION_NAME: Companion name (default: "Master")
         EGO_MCP_WORKSPACE_DIR: OpenClaw workspace root for Markdown sync (optional)
+        EGO_MCP_TIMEZONE: IANA timezone ID (default: "UTC")
     """
 
     embedding_provider: str
@@ -41,6 +43,7 @@ class EgoConfig:
     data_dir: Path
     companion_name: str
     workspace_dir: Path | None
+    timezone: str
 
     @classmethod
     def from_env(cls) -> EgoConfig:
@@ -73,6 +76,14 @@ class EgoConfig:
         companion_name = os.environ.get("EGO_MCP_COMPANION_NAME", "Master")
         workspace_dir_raw = os.environ.get("EGO_MCP_WORKSPACE_DIR", "").strip()
         workspace_dir = Path(workspace_dir_raw) if workspace_dir_raw else None
+        timezone = os.environ.get("EGO_MCP_TIMEZONE", "UTC")
+        try:
+            ZoneInfo(timezone)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(
+                f"Invalid timezone '{timezone}' in EGO_MCP_TIMEZONE. "
+                "Use an IANA timezone ID (e.g. 'UTC', 'Asia/Tokyo')."
+            ) from exc
 
         return cls(
             embedding_provider=provider,
@@ -81,4 +92,5 @@ class EgoConfig:
             data_dir=data_dir,
             companion_name=companion_name,
             workspace_dir=workspace_dir,
+            timezone=timezone,
         )

--- a/ego-mcp/src/ego_mcp/consolidation.py
+++ b/ego-mcp/src/ego_mcp/consolidation.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Sequence
+
+from ego_mcp import timezone_utils
 
 if TYPE_CHECKING:
     from ego_mcp.memory import MemoryStore
@@ -86,7 +88,7 @@ class ConsolidationEngine:
         similarity-based links between them.
         """
         effective_window = window if window is not None else window_hours
-        cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, effective_window))
+        cutoff = timezone_utils.now() - timedelta(hours=max(1, effective_window))
         recent = await store.list_recent(n=max_replay_events * 2)
         recent = self._collect_replay_targets(recent, cutoff)
 
@@ -186,7 +188,7 @@ class ConsolidationEngine:
         try:
             ts = datetime.fromisoformat(timestamp)
             if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
+                ts = ts.replace(tzinfo=timezone_utils.app_timezone())
             return ts >= cutoff
         except ValueError:
             return False

--- a/ego-mcp/src/ego_mcp/desire.py
+++ b/ego-mcp/src/ego_mcp/desire.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import math
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from ego_mcp import timezone_utils
 
 # Desire definitions: name → {satisfaction_hours, level (Maslow tier)}
 DESIRES: dict[str, dict[str, Any]] = {
@@ -68,7 +70,7 @@ class DesireEngine:
 
     def _init_default_state(self) -> dict[str, dict[str, Any]]:
         """Create default state for all desires."""
-        now = datetime.now(timezone.utc).isoformat()
+        now = timezone_utils.now().isoformat()
         return {
             name: {
                 "last_satisfied": now,
@@ -88,7 +90,7 @@ class DesireEngine:
         prediction_error: dict[str, float] | None = None,
     ) -> dict[str, float]:
         """Compute current level for all desires with transient modulation."""
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
         levels: dict[str, float] = {}
         context_boosts = context_boosts or {}
         emotional_modulation = emotional_modulation or {}
@@ -104,7 +106,7 @@ class DesireEngine:
                 try:
                     last = datetime.fromisoformat(last_str)
                     if last.tzinfo is None:
-                        last = last.replace(tzinfo=timezone.utc)
+                        last = last.replace(tzinfo=timezone_utils.app_timezone())
                     elapsed = (now - last).total_seconds() / 3600
                 except ValueError:
                     elapsed = config["satisfaction_hours"]  # assume half
@@ -134,7 +136,7 @@ class DesireEngine:
         if name not in DESIRES:
             raise ValueError(f"Unknown desire: {name}")
 
-        now = datetime.now(timezone.utc).isoformat()
+        now = timezone_utils.now().isoformat()
         if name not in self._state:
             self._state[name] = {}
         self._state[name]["last_satisfied"] = now
@@ -164,7 +166,7 @@ class DesireEngine:
 
         if name not in self._state:
             self._state[name] = {
-                "last_satisfied": datetime.now(timezone.utc).isoformat(),
+                "last_satisfied": timezone_utils.now().isoformat(),
                 "satisfaction_quality": 0.5,
                 "boost": 0.0,
             }

--- a/ego-mcp/src/ego_mcp/interoception.py
+++ b/ego-mcp/src/ego_mcp/interoception.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
+from ego_mcp import timezone_utils
+
 try:
     import psutil  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover
@@ -14,7 +16,7 @@ except Exception:  # pragma: no cover
 def time_phase(now: datetime | None = None) -> str:
     """Classify current time into coarse cognitive phases."""
     if now is None:
-        now = datetime.now()
+        now = timezone_utils.now()
     hour = now.hour
     if 0 <= hour <= 4:
         return "late_night"
@@ -62,7 +64,7 @@ def get_body_state() -> dict[str, str]:
     uptime_hours = "0.0"
     if psutil is not None:
         try:
-            uptime_seconds = datetime.now().timestamp() - float(psutil.boot_time())
+            uptime_seconds = timezone_utils.now().timestamp() - float(psutil.boot_time())
             uptime_hours = f"{max(0.0, uptime_seconds / 3600):.1f}"
         except Exception:
             uptime_hours = "0.0"

--- a/ego-mcp/src/ego_mcp/logging_utils.py
+++ b/ego-mcp/src/ego_mcp/logging_utils.py
@@ -11,6 +11,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from ego_mcp import timezone_utils
+
 TRACE_LEVEL_NUM = 5
 logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
 
@@ -84,7 +86,7 @@ def _parse_log_level(value: str | None) -> int:
 
 def get_log_path() -> Path:
     log_dir = Path(os.getenv("EGO_MCP_LOG_DIR", "/tmp")).expanduser()
-    date_stamp = datetime.now().strftime("%Y-%m-%d")
+    date_stamp = timezone_utils.now().strftime("%Y-%m-%d")
     return log_dir / f"ego-mcp-{date_stamp}.log"
 
 

--- a/ego-mcp/src/ego_mcp/migrations/0002_desire_rebalance.py
+++ b/ego-mcp/src/ego_mcp/migrations/0002_desire_rebalance.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
+
+from ego_mcp import timezone_utils
 
 TARGET_VERSION = "0.2.0"
 
@@ -22,7 +23,7 @@ def up(data_dir: Path) -> None:
     if not isinstance(payload, dict):
         return
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = timezone_utils.now().isoformat()
     for state in payload.values():
         if isinstance(state, dict):
             state["last_satisfied"] = now_iso

--- a/ego-mcp/src/ego_mcp/relationship.py
+++ b/ego-mcp/src/ego_mcp/relationship.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import dataclasses
 import json
 from dataclasses import asdict
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ego_mcp import timezone_utils
 from ego_mcp.types import RelationshipModel
 
 _UPDATABLE_FIELDS = frozenset(
@@ -140,7 +140,7 @@ class RelationshipStore:
     ) -> RelationshipModel:
         """Update model fields inferred from recent ToM analysis."""
         raw = self._get_raw(person_id)
-        now = datetime.now(timezone.utc).isoformat()
+        now = timezone_utils.now().isoformat()
 
         if dominant_tone and dominant_tone != "unknown tone":
             trajectory = raw.get("recent_mood_trajectory", [])

--- a/ego-mcp/src/ego_mcp/self_model.py
+++ b/ego-mcp/src/ego_mcp/self_model.py
@@ -6,10 +6,11 @@ import json
 import math
 import uuid
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from ego_mcp import timezone_utils
 from ego_mcp.types import SelfModel
 
 
@@ -31,7 +32,7 @@ def _parse_question_timestamp(timestamp: str) -> datetime | None:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.replace(tzinfo=timezone_utils.app_timezone())
     return parsed
 
 
@@ -41,9 +42,9 @@ def _age_days_since(timestamp: str, now: datetime | None = None) -> float:
     if parsed is None:
         return 0.0
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
     if now.tzinfo is None:
-        now = now.replace(tzinfo=timezone.utc)
+        now = now.replace(tzinfo=timezone_utils.app_timezone())
     delta = (now - parsed).total_seconds()
     if delta <= 0:
         return 0.0
@@ -73,7 +74,7 @@ class SelfModelStore:
         data = asdict(model)
         data["unresolved_questions"] = []
         data["question_log"] = []
-        data["last_updated"] = datetime.now(timezone.utc).isoformat()
+        data["last_updated"] = timezone_utils.now().isoformat()
         return data
 
     def _load(self) -> None:
@@ -119,7 +120,7 @@ class SelfModelStore:
     def update(self, patch: dict[str, Any]) -> SelfModel:
         for key, value in patch.items():
             self._data[key] = value
-        self._data["last_updated"] = datetime.now(timezone.utc).isoformat()
+        self._data["last_updated"] = timezone_utils.now().isoformat()
         self._save()
         return self.get()
 
@@ -151,7 +152,7 @@ class SelfModelStore:
         question_log = self._data.get("question_log", [])
         if not isinstance(question_log, list):
             question_log = []
-        now_iso = datetime.now(timezone.utc).isoformat()
+        now_iso = timezone_utils.now().isoformat()
         question_log.append(
             {
                 "id": question_id,
@@ -168,7 +169,7 @@ class SelfModelStore:
             unresolved = []
         unresolved.append(question_id)
         self._data["unresolved_questions"] = unresolved
-        self._data["last_updated"] = datetime.now(timezone.utc).isoformat()
+        self._data["last_updated"] = timezone_utils.now().isoformat()
 
         self._save()
         return question_id
@@ -187,7 +188,7 @@ class SelfModelStore:
                 if isinstance(item, dict) and item.get("id") == question_id:
                     item["resolved"] = True
                     break
-        self._data["last_updated"] = datetime.now(timezone.utc).isoformat()
+        self._data["last_updated"] = timezone_utils.now().isoformat()
         self._save()
         return True
 
@@ -200,7 +201,7 @@ class SelfModelStore:
         for item in question_log:
             if isinstance(item, dict) and item.get("id") == question_id:
                 item["importance"] = _clamp_question_importance(importance)
-                self._data["last_updated"] = datetime.now(timezone.utc).isoformat()
+                self._data["last_updated"] = timezone_utils.now().isoformat()
                 self._save()
                 return True
         return False
@@ -224,7 +225,7 @@ class SelfModelStore:
 
     def get_unresolved_questions_with_salience(self) -> list[dict[str, Any]]:
         """Return all unresolved questions enriched with salience and age metadata."""
-        now = datetime.now(timezone.utc)
+        now = timezone_utils.now()
 
         unresolved_ids_raw = self._data.get("unresolved_questions", [])
         unresolved_ids = (

--- a/ego-mcp/src/ego_mcp/timezone_utils.py
+++ b/ego-mcp/src/ego_mcp/timezone_utils.py
@@ -1,0 +1,43 @@
+"""Timezone helpers driven by environment configuration."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_TIMEZONE_ENV = "EGO_MCP_TIMEZONE"
+_DEFAULT_TIMEZONE = "UTC"
+
+
+def timezone_name() -> str:
+    """Return configured timezone ID."""
+    return os.environ.get(_TIMEZONE_ENV, _DEFAULT_TIMEZONE)
+
+
+def app_timezone() -> tzinfo:
+    """Return configured IANA timezone.
+
+    Raises:
+        ValueError: if the configured timezone ID is invalid.
+    """
+    name = timezone_name()
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(
+            f"Invalid timezone '{name}' in {_TIMEZONE_ENV}. Use an IANA timezone ID (e.g. 'UTC', 'Asia/Tokyo')."
+        ) from exc
+
+
+def now() -> datetime:
+    """Return current time in configured timezone."""
+    return datetime.now(tz=app_timezone())
+
+
+def localize(dt: datetime) -> datetime:
+    """Ensure datetime is timezone-aware in configured timezone."""
+    tz = app_timezone()
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt.astimezone(tz)

--- a/ego-mcp/src/ego_mcp/types.py
+++ b/ego-mcp/src/ego_mcp/types.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
+
+from ego_mcp import timezone_utils
 
 
 class Emotion(str, Enum):
@@ -99,7 +100,7 @@ class Memory:
     @staticmethod
     def now_iso() -> str:
         """Return current UTC time as ISO 8601 string."""
-        return datetime.now(timezone.utc).isoformat()
+        return timezone_utils.now().isoformat()
 
 
 @dataclass

--- a/ego-mcp/src/ego_mcp/workspace_sync.py
+++ b/ego-mcp/src/ego_mcp/workspace_sync.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
+from ego_mcp import timezone_utils
 from ego_mcp.types import Category, Memory
 
 
@@ -134,7 +135,7 @@ def _timestamp_parts(timestamp: str) -> tuple[str, str]:
     try:
         parsed = datetime.fromisoformat(timestamp)
         if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
+            parsed = parsed.replace(tzinfo=timezone_utils.app_timezone())
     except ValueError:
-        parsed = datetime.now(timezone.utc)
+        parsed = timezone_utils.now()
     return parsed.strftime("%Y-%m-%d"), parsed.strftime("%H:%M")

--- a/ego-mcp/tests/test_chromadb_compat.py
+++ b/ego-mcp/tests/test_chromadb_compat.py
@@ -24,6 +24,7 @@ def test_init_server_uses_real_chromadb_client(tmp_path: Path) -> None:
         data_dir=tmp_path / "ego-data",
         companion_name="Master",
         workspace_dir=None,
+        timezone="UTC",
     )
 
     server_mod.init_server(config)

--- a/ego-mcp/tests/test_config.py
+++ b/ego-mcp/tests/test_config.py
@@ -21,6 +21,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "EGO_MCP_DATA_DIR",
         "EGO_MCP_COMPANION_NAME",
         "EGO_MCP_WORKSPACE_DIR",
+        "EGO_MCP_TIMEZONE",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -38,6 +39,7 @@ class TestGeminiDefaults:
         assert config.companion_name == "Master"
         assert config.data_dir == Path.home() / ".ego-mcp" / "data"
         assert config.workspace_dir is None
+        assert config.timezone == "UTC"
 
 
 class TestOpenAIExplicit:
@@ -117,3 +119,18 @@ class TestCustomSettings:
         config = EgoConfig.from_env()
 
         assert config.workspace_dir == Path("/tmp/openclaw-workspace")
+
+
+    def test_custom_timezone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("EGO_MCP_TIMEZONE", "Asia/Tokyo")
+        config = EgoConfig.from_env()
+
+        assert config.timezone == "Asia/Tokyo"
+
+    def test_invalid_timezone_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("EGO_MCP_TIMEZONE", "Invalid/Timezone")
+
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            EgoConfig.from_env()


### PR DESCRIPTION
### Motivation
- Provide a single, environment-configurable timezone for all app time handling using an IANA timezone ID via `EGO_MCP_TIMEZONE`. 
- Replace hardcoded UTC/local datetime usage spread across the codebase with a single source of truth so timestamps, comparisons, and formatted outputs are consistent with the configured zone.

### Description
- Add `ego_mcp.timezone_utils` offering `timezone_name()`, `app_timezone()`, `now()` and `localize()` which derive behavior from `EGO_MCP_TIMEZONE` and validate IANA IDs.
- Extend `EgoConfig` to read and validate `EGO_MCP_TIMEZONE` (default `UTC`) and expose `timezone` on the config object.
- Update time-dependent modules to use `timezone_utils.now()` and `timezone_utils.app_timezone()` instead of ad-hoc `datetime.now(timezone.utc)` / naive-UTC replacement; files touched include `desire`, `self_model`, `types`, `consolidation`, `interoception`, `logging_utils`, `_server_*` modules, `workspace_sync`, `relationship`, `_memory_scoring`, and migration `0002_desire_rebalance`.
- Add/adjust tests to cover the new config field and timezone validation in `tests/test_config.py` and update `tests/test_chromadb_compat.py` to construct `EgoConfig` with the new field.

### Testing
- Ran `python -m compileall src/ego_mcp` which succeeded.
- Ran `PYTHONPATH=src pytest tests/test_config.py -v` and `PYTHONPATH=src pytest tests/test_config.py tests/test_self_model.py -v`, both runs passed (13 and 26 tests passed respectively).
- Ran `isort` and `ruff` checks and applied fixes where needed; final `isort --check-only src tests` and `ruff check src tests` passed.
- `mypy` was run but failed in this environment due to a missing optional dependency (`respx`) and unrelated baseline typing issues in some tests, so type-checking needs CI / developer environment with dependencies available to fully validate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81e6bbd688324acf09a9fa62d3b40)