### PR TITLE
Add legend-based series toggles to history charts

### DIFF
--- a/dashboard/frontend/src/components/history/desire-history-chart.tsx
+++ b/dashboard/frontend/src/components/history/desire-history-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import {
   CartesianGrid,
   Line,
@@ -40,6 +40,7 @@ export const DesireHistoryChart = ({
   markers = [],
 }: DesireHistoryChartProps) => {
   const { formatTs } = useTimestampFormatter()
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set())
   const { chartConfig, dynamicKeys } = useMemo(() => {
     const fixedKeySet = new Set<string>(DESIRE_METRIC_KEYS)
     const dynamicKeys = desireKeys.filter((key) => !fixedKeySet.has(key))
@@ -70,6 +71,26 @@ export const DesireHistoryChart = ({
       ),
     [markers],
   )
+  const allSeriesKeys = useMemo(
+    () => [...DESIRE_METRIC_KEYS, ...dynamicKeys],
+    [dynamicKeys],
+  )
+  const visibleKeys = useMemo(
+    () => allSeriesKeys.filter((key) => !hiddenKeys.has(key)),
+    [allSeriesKeys, hiddenKeys],
+  )
+
+  const toggleSeries = (key: string) => {
+    setHiddenKeys((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
 
   return (
     <Card>
@@ -88,10 +109,13 @@ export const DesireHistoryChart = ({
                   labelFormatter={formatTs}
                   showAllSeries
                   missingValueLabel="-"
+                  visibleKeys={visibleKeys}
                 />
               }
             />
-            <ChartLegend content={<ChartLegendContent />} />
+            <ChartLegend
+              content={<ChartLegendContent onSeriesToggle={toggleSeries} />}
+            />
             {desireMarkers.map((marker) => (
               <ReferenceLine
                 key={`${marker.kind}-${marker.ts}-${marker.desire_key ?? marker.detail ?? ''}`}
@@ -126,6 +150,7 @@ export const DesireHistoryChart = ({
                 stroke={resolveDesireSeriesColor(key, chartConfig, 0)}
                 dot={false}
                 connectNulls
+                hide={hiddenKeys.has(key)}
               />
             ))}
             {dynamicKeys.map((key, index) => (
@@ -138,6 +163,7 @@ export const DesireHistoryChart = ({
                 strokeDasharray="4 2"
                 dot={false}
                 connectNulls
+                hide={hiddenKeys.has(key)}
               />
             ))}
           </LineChart>

--- a/dashboard/frontend/src/components/history/tool-usage-chart-utils.ts
+++ b/dashboard/frontend/src/components/history/tool-usage-chart-utils.ts
@@ -1,0 +1,22 @@
+type TooltipPayloadItem = {
+  dataKey?: string | number
+  type?: string
+  value?: unknown
+}
+
+export const shouldShowToolUsageTooltip = (
+  payload: TooltipPayloadItem[] | undefined,
+  visibleKeys: string[],
+) =>
+  (payload ?? []).some((item) => {
+    if (item.type === 'none') return false
+
+    const key = `${item.dataKey ?? ''}`
+    if (key.length > 0 && !visibleKeys.includes(key)) {
+      return false
+    }
+
+    return typeof item.value === 'number'
+      ? item.value !== 0
+      : item.value !== null && item.value !== undefined
+  })

--- a/dashboard/frontend/src/components/history/tool-usage-chart.test.tsx
+++ b/dashboard/frontend/src/components/history/tool-usage-chart.test.tsx
@@ -1,0 +1,39 @@
+import { shouldShowToolUsageTooltip } from '@/components/history/tool-usage-chart-utils'
+
+describe('shouldShowToolUsageTooltip', () => {
+  it('returns false when every visible series is zero', () => {
+    expect(
+      shouldShowToolUsageTooltip(
+        [
+          { dataKey: 'read_file', type: 'line', value: 0 },
+          { dataKey: 'write_file', type: 'line', value: 0 },
+        ],
+        ['read_file', 'write_file'],
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true when any visible series has a non-zero value', () => {
+    expect(
+      shouldShowToolUsageTooltip(
+        [
+          { dataKey: 'read_file', type: 'line', value: 0 },
+          { dataKey: 'write_file', type: 'line', value: 2 },
+        ],
+        ['read_file', 'write_file'],
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores hidden series values', () => {
+    expect(
+      shouldShowToolUsageTooltip(
+        [
+          { dataKey: 'read_file', type: 'line', value: 0 },
+          { dataKey: 'write_file', type: 'line', value: 3 },
+        ],
+        ['read_file'],
+      ),
+    ).toBe(false)
+  })
+})

--- a/dashboard/frontend/src/components/history/tool-usage-chart.tsx
+++ b/dashboard/frontend/src/components/history/tool-usage-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Area,
   AreaChart,
@@ -17,6 +17,7 @@ import {
   type ChartConfig,
 } from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { shouldShowToolUsageTooltip } from '@/components/history/tool-usage-chart-utils'
 import { TOOL_CHART_COLORS } from '@/constants'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { StringPoint, UsagePoint } from '@/types'
@@ -38,12 +39,19 @@ const PHASE_COLORS: Record<string, string> = {
 
 type PhaseSpan = { x1: string; x2: string; phase: string }
 
+type TooltipPayloadItem = {
+  dataKey?: string | number
+  type?: string
+  value?: unknown
+}
+
 export const ToolUsageChart = ({
   usage,
   toolSeriesKeys,
   timeline,
 }: ToolUsageChartProps) => {
   const { formatTs } = useTimestampFormatter()
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set())
 
   const config: ChartConfig = Object.fromEntries(
     toolSeriesKeys.map((key, i) => [
@@ -73,6 +81,22 @@ export const ToolUsageChart = ({
     })
     return spans
   }, [timeline])
+  const visibleKeys = useMemo(
+    () => toolSeriesKeys.filter((key) => !hiddenKeys.has(key)),
+    [toolSeriesKeys, hiddenKeys],
+  )
+
+  const toggleSeries = (key: string) => {
+    setHiddenKeys((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
 
   return (
     <Card>
@@ -101,11 +125,31 @@ export const ToolUsageChart = ({
             <XAxis dataKey="ts" hide />
             <YAxis />
             <ChartTooltip
-              content={
-                <ChartTooltipContent labelFormatter={formatTs} showAllSeries />
-              }
+              content={({ active, label, payload }) => {
+                if (
+                  !shouldShowToolUsageTooltip(
+                    payload as TooltipPayloadItem[] | undefined,
+                    visibleKeys,
+                  )
+                ) {
+                  return null
+                }
+
+                return (
+                  <ChartTooltipContent
+                    active={active}
+                    label={label}
+                    payload={payload}
+                    labelFormatter={formatTs}
+                    showAllSeries
+                    visibleKeys={visibleKeys}
+                  />
+                )
+              }}
             />
-            <ChartLegend content={<ChartLegendContent />} />
+            <ChartLegend
+              content={<ChartLegendContent onSeriesToggle={toggleSeries} />}
+            />
             {toolSeriesKeys.map((toolName) => (
               <Area
                 key={toolName}
@@ -115,6 +159,7 @@ export const ToolUsageChart = ({
                 stroke={`var(--color-${toolName})`}
                 fill={`var(--color-${toolName})`}
                 fillOpacity={0.4}
+                hide={hiddenKeys.has(toolName)}
               />
             ))}
           </AreaChart>

--- a/dashboard/frontend/src/components/history/valence-arousal-chart.test.tsx
+++ b/dashboard/frontend/src/components/history/valence-arousal-chart.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { ValenceArousalChart } from '@/components/history/valence-arousal-chart'
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts')
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => {
+      if (React.isValidElement(children)) {
+        return React.cloneElement(
+          children as React.ReactElement<{ width?: number; height?: number }>,
+          { width: 800, height: 300 },
+        )
+      }
+
+      return children
+    },
+  }
+})
+
+describe('ValenceArousalChart', () => {
+  it('toggles a series from the legend', () => {
+    const { container } = render(
+      <ValenceArousalChart
+        valence={[
+          { ts: '2026-01-01T12:00:00Z', value: 0.2 },
+          { ts: '2026-01-01T12:05:00Z', value: 0.4 },
+        ]}
+        arousal={[
+          { ts: '2026-01-01T12:00:00Z', value: -0.3 },
+          { ts: '2026-01-01T12:05:00Z', value: 0.1 },
+        ]}
+      />,
+    )
+
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(2)
+
+    const valenceLegend = screen.getByRole('button', { name: 'valence' })
+    expect(valenceLegend).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(valenceLegend)
+
+    expect(valenceLegend).toHaveAttribute('aria-pressed', 'false')
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1)
+
+    fireEvent.click(valenceLegend)
+
+    expect(valenceLegend).toHaveAttribute('aria-pressed', 'true')
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(2)
+  })
+})

--- a/dashboard/frontend/src/components/history/valence-arousal-chart.tsx
+++ b/dashboard/frontend/src/components/history/valence-arousal-chart.tsx
@@ -11,7 +11,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { SeriesPoint } from '@/types'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 type ValenceArousalChartProps = {
   valence: SeriesPoint[]
@@ -28,6 +28,7 @@ export const ValenceArousalChart = ({
   arousal,
 }: ValenceArousalChartProps) => {
   const { formatTs } = useTimestampFormatter()
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(new Set())
 
   const data = useMemo(() => {
     const byTs = new Map<
@@ -46,6 +47,22 @@ export const ValenceArousalChart = ({
     }
     return Array.from(byTs.values()).sort((a, b) => a.ts.localeCompare(b.ts))
   }, [valence, arousal])
+  const visibleKeys = useMemo(
+    () => ['valence', 'arousal'].filter((key) => !hiddenKeys.has(key)),
+    [hiddenKeys],
+  )
+
+  const toggleSeries = (key: string) => {
+    setHiddenKeys((current) => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
 
   if (data.length === 0) return null
 
@@ -66,16 +83,20 @@ export const ValenceArousalChart = ({
                   labelFormatter={formatTs}
                   showAllSeries
                   missingValueLabel="-"
+                  visibleKeys={visibleKeys}
                 />
               }
             />
-            <ChartLegend content={<ChartLegendContent />} />
+            <ChartLegend
+              content={<ChartLegendContent onSeriesToggle={toggleSeries} />}
+            />
             <Line
               type="monotone"
               dataKey="valence"
               stroke="var(--color-valence)"
               dot={false}
               connectNulls
+              hide={hiddenKeys.has('valence')}
             />
             <Line
               type="monotone"
@@ -83,6 +104,7 @@ export const ValenceArousalChart = ({
               stroke="var(--color-arousal)"
               dot={false}
               connectNulls
+              hide={hiddenKeys.has('arousal')}
             />
           </LineChart>
         </ChartContainer>

--- a/dashboard/frontend/src/components/ui/chart.tsx
+++ b/dashboard/frontend/src/components/ui/chart.tsx
@@ -130,6 +130,7 @@ function ChartTooltipContent({
   labelKey,
   showAllSeries = false,
   missingValueLabel = '-',
+  visibleKeys,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<'div'> & {
     hideLabel?: boolean
@@ -139,6 +140,7 @@ function ChartTooltipContent({
     labelKey?: string
     showAllSeries?: boolean
     missingValueLabel?: string
+    visibleKeys?: string[]
   }) {
   const { config } = useChart()
   const filteredPayload = React.useMemo(
@@ -157,7 +159,9 @@ function ChartTooltipContent({
       byKey.set(key, item)
     }
 
-    return Object.keys(config).map(
+    const keysToRender = visibleKeys ?? Object.keys(config)
+
+    return keysToRender.map(
       (key) =>
         byKey.get(key) ?? {
           name: key,
@@ -167,7 +171,7 @@ function ChartTooltipContent({
           payload: {},
         },
     )
-  }, [config, filteredPayload, nameKey, showAllSeries])
+  }, [config, filteredPayload, nameKey, showAllSeries, visibleKeys])
 
   const tooltipLabel = React.useMemo(() => {
     if (hideLabel || !payload?.length) {
@@ -320,10 +324,12 @@ function ChartLegendContent({
   payload,
   verticalAlign = 'bottom',
   nameKey,
+  onSeriesToggle,
 }: React.ComponentProps<'div'> &
   Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
     hideIcon?: boolean
     nameKey?: string
+    onSeriesToggle?: (key: string) => void
   }) {
   const { config } = useChart()
 
@@ -344,13 +350,25 @@ function ChartLegendContent({
         .map((item) => {
           const key = `${nameKey || item.dataKey || 'value'}`
           const itemConfig = getPayloadConfigFromPayload(config, item, key)
+          const label = itemConfig?.label || String(item.value ?? key)
+          const isInactive = item.inactive === true
+          const classes = cn(
+            '[&>svg]:text-muted-foreground flex min-w-0 max-w-full items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
+            isInactive && 'opacity-50',
+          )
 
           return (
-            <div
-              key={item.value}
+            <button
+              key={String(item.dataKey ?? item.value)}
+              type="button"
               className={cn(
-                '[&>svg]:text-muted-foreground flex min-w-0 max-w-full items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
+                classes,
+                onSeriesToggle &&
+                  'hover:bg-muted/50 focus-visible:ring-ring/50 rounded-sm px-1 py-0.5 text-left outline-none focus-visible:ring-[3px]',
               )}
+              onClick={() => onSeriesToggle?.(key)}
+              aria-pressed={!isInactive}
+              disabled={!onSeriesToggle}
             >
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
@@ -363,9 +381,9 @@ function ChartLegendContent({
                 />
               )}
               <span className="min-w-0 break-words whitespace-normal leading-tight">
-                {itemConfig?.label}
+                {label}
               </span>
-            </div>
+            </button>
           )
         })}
     </div>


### PR DESCRIPTION
## Summary
- add clickable legend items to history charts so users can hide and re-show series
- update shared chart legend and tooltip handling to respect visible series state
- suppress `Tool usage history` tooltips when all currently visible series are `0` or missing
- add tests for valence/arousal legend toggling and tool usage tooltip filtering

## Testing
- `npm ci`
- `npm run lint`
- `npm run format:check`
- `npm run test`
- `npm run build`
- `uv sync --project dashboard --group dev`
- `uv run --directory dashboard pytest -v`
- `uv run --directory dashboard ruff check src tests`
- `uv run --directory dashboard ruff format --check src tests`
- `uv run --directory dashboard mypy src tests`
- `docker compose config`