### PR TITLE
Fix dashboard total call overcounting across ingestor restarts

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -28,6 +28,8 @@ docker compose up --build
 - db (TimescaleDB): `localhost:5432`
 - redis: `localhost:6379`
 - ingestor: `DASHBOARD_LOG_PATH`（file または glob）を tail して DB/Redis に反映
+  - `ingestion_checkpoints` に file ごとの inode/offset を保持し、再起動後は前回位置から再開
+  - `dedupe_key` により replay された既存 JSONL は二重計上しない
 
 `ego-mcp` は `EGO_MCP_LOG_DIR`（既定 `/tmp`）配下に
 `ego-mcp-YYYY-MM-DD.log` を出力します。dashboard 側はこの仕様に合わせて、
@@ -56,6 +58,15 @@ uv run pytest -v
 uv run ruff check src tests
 uv run ruff format --check src tests
 uv run mypy src tests
+```
+
+### メンテナンス
+
+既存データの replay 重複を補正しつつ、現在のログ終端を checkpoint 化したい場合:
+
+```bash
+cd dashboard
+uv run python -m ego_dashboard.dedupe_telemetry --log-path "${DASHBOARD_LOG_PATH}"
 ```
 
 ### frontend

--- a/dashboard/docs/api.md
+++ b/dashboard/docs/api.md
@@ -9,7 +9,7 @@
 - `GET /api/v1/current`
   - 現在値サマリ（latest / tool_calls_per_min / error_rate）
 - `GET /api/v1/usage/tools?from=...&to=...&bucket=1m|5m|15m`
-  - ツール別使用回数系列
+  - ツール別使用回数系列。`Tool invocation` log を 1 call = 1 count として集計し、log が無い旧データのみ terminal event へフォールバック
 - `GET /api/v1/metrics/{key}?from=...&to=...&bucket=...`
   - 数値メトリクス平均系列
 - `GET /api/v1/metrics/{key}/string-timeline?from=...&to=...`

--- a/dashboard/docs/configuration.md
+++ b/dashboard/docs/configuration.md
@@ -23,6 +23,8 @@
 
 - `DASHBOARD_DATABASE_URL` と `DASHBOARD_REDIS_URL` の両方が設定されると `SqlTelemetryStore` を使用
 - どちらか欠ける場合は `TelemetryStore`（in-memory）へフォールバック
+- `SqlTelemetryStore` は `tool_events` / `log_events` に `dedupe_key` を保持し、同一 `(ts, dedupe_key)` の再投入を無視する
+- 再起動 resume 用の offset は `ingestion_checkpoints` テーブルに保存する
 
 ### CORS 設定（AllowedOrigin）
 
@@ -39,7 +41,8 @@
 - `ego-mcp` は `ego-mcp-YYYY-MM-DD.log` 形式の日付付き JSONL ログを出力
 - `dashboard` の `DASHBOARD_LOG_PATH` は単一ファイルだけでなく glob も受け付ける
 - compose ではホストの `DASHBOARD_LOG_MOUNT_SOURCE`（既定 `/tmp`）をコンテナに read-only mount
-- ingestor は inode 変更 / truncate と、glob の最新一致ファイルへの切替（日次ローテーション相当）に対応
+- ingestor は inode 変更 / truncate と、glob に一致した全ファイルの個別 checkpoint に対応する
+- 再起動時は `ingestion_checkpoints` の inode/offset が一致する file をその位置から再開し、一致しない場合は先頭から再読込する
 - `DASHBOARD_EGO_MCP_DATA_DIR` を設定した場合、compose はその絶対パスを backend コンテナ内の同じパスへ read-only mount する
 
 ## 運用者向け
@@ -59,3 +62,4 @@
 - `DASHBOARD_LOG_PATH=/host-tmp/ego-mcp-*.log`（compose）
 - `DASHBOARD_INGEST_POLL_SECONDS=1.0`（通常）
 - 高負荷時は `1.5-2.0` 秒へ調整
+- 補正用途: `uv run python -m ego_dashboard.dedupe_telemetry --log-path "$DASHBOARD_LOG_PATH"`

--- a/dashboard/docs/operations.md
+++ b/dashboard/docs/operations.md
@@ -29,13 +29,15 @@
 
 ### ログローテーション
 
-- ingestor は inode 変更 / truncate を検知して再追従し、glob 指定時は最新一致ファイルに切替
+- ingestor は inode 変更 / truncate を検知して再追従し、glob 指定時も file ごとの checkpoint を保持する
 - ローテーション方式は `copytruncate` より rename + reopen 推奨
 
 ### 障害対応（よくある事象）
 
 - 画面は開くが数値が増えない:
   - ingestor が停止している、または `DASHBOARD_LOG_PATH` / `DASHBOARD_LOG_MOUNT_SOURCE` が誤っている
+- ingestor 再起動後に tool calls が急増した:
+  - `uv run python -m ego_dashboard.dedupe_telemetry --log-path "$DASHBOARD_LOG_PATH"` を実行して既存 replay 重複を除去し、checkpoint を現在 EOF に初期化する
 - Logs タブが空:
   - 取り込み元 JSONL に log event が含まれていない
 - compose 起動時に frontend から API 接続できない:

--- a/dashboard/scripts/dedupe_telemetry.py
+++ b/dashboard/scripts/dedupe_telemetry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from ego_dashboard.dedupe_telemetry import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/src/ego_dashboard/dedupe_telemetry.py
+++ b/dashboard/src/ego_dashboard/dedupe_telemetry.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import psycopg
+
+from ego_dashboard.ingestor import _resolve_source_files
+from ego_dashboard.models import DashboardEvent, LogEvent
+from ego_dashboard.sql_store import SqlTelemetryStore
+from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
+
+_BATCH_SIZE = 1000
+
+
+@dataclass(frozen=True)
+class CleanupStats:
+    backfilled_tool_events: int
+    backfilled_log_events: int
+    deleted_tool_duplicates: int
+    deleted_log_duplicates: int
+    initialized_checkpoints: int
+
+
+def _iter_cursor_rows(cursor: Any, *, batch_size: int = _BATCH_SIZE) -> list[tuple[Any, ...]]:
+    fetchmany = getattr(cursor, "fetchmany", None)
+    if callable(fetchmany):
+        rows: list[tuple[Any, ...]] = []
+        while True:
+            batch = fetchmany(batch_size)
+            if not batch:
+                return rows
+            rows.extend(batch)
+    return list(cursor.fetchall())
+
+
+def build_tool_event_dedupe_updates(
+    rows: list[tuple[Any, ...]],
+) -> list[tuple[str, object, str]]:
+    updates: list[tuple[str, object, str]] = []
+    for row in rows:
+        if len(row) != 13:
+            continue
+        (
+            ctid,
+            ts,
+            event_type,
+            tool_name,
+            ok,
+            duration_ms,
+            emotion_primary,
+            emotion_intensity,
+            numeric_metrics,
+            string_metrics,
+            params,
+            private,
+            message,
+        ) = row
+        if not isinstance(ctid, str):
+            continue
+        event = DashboardEvent(
+            ts=ts,
+            event_type=str(event_type),
+            tool_name=str(tool_name),
+            ok=bool(ok),
+            duration_ms=duration_ms if isinstance(duration_ms, int) else None,
+            emotion_primary=emotion_primary if isinstance(emotion_primary, str) else None,
+            emotion_intensity=(
+                float(emotion_intensity) if isinstance(emotion_intensity, (int, float)) else None
+            ),
+            numeric_metrics=numeric_metrics if isinstance(numeric_metrics, dict) else {},
+            string_metrics=string_metrics if isinstance(string_metrics, dict) else {},
+            params=params if isinstance(params, dict) else {},
+            private=bool(private),
+            message=message if isinstance(message, str) else None,
+        )
+        updates.append((ctid, ts, dashboard_event_dedupe_key(event)))
+    return updates
+
+
+def build_log_event_dedupe_updates(rows: list[tuple[Any, ...]]) -> list[tuple[str, object, str]]:
+    updates: list[tuple[str, object, str]] = []
+    for row in rows:
+        if len(row) != 7:
+            continue
+        ctid, ts, level, logger, message, private, fields = row
+        if not isinstance(ctid, str):
+            continue
+        event = LogEvent(
+            ts=ts,
+            level=str(level),
+            logger=str(logger),
+            message=str(message),
+            private=bool(private),
+            fields=fields if isinstance(fields, dict) else {},
+        )
+        updates.append((ctid, ts, log_event_dedupe_key(event)))
+    return updates
+
+
+def partition_dedupe_updates(
+    rows: list[tuple[str, object, str]],
+    *,
+    existing: set[tuple[object, str]] | None = None,
+) -> tuple[list[tuple[str, str]], list[str]]:
+    updates: list[tuple[str, str]] = []
+    duplicate_ctids: list[str] = []
+    seen = set(existing or set())
+    for ctid, ts, dedupe_key in rows:
+        identity = (ts, dedupe_key)
+        if identity in seen:
+            duplicate_ctids.append(ctid)
+            continue
+        seen.add(identity)
+        updates.append((ctid, dedupe_key))
+    return updates, duplicate_ctids
+
+
+def _backfill_tool_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int, int]:
+    cursor.execute(
+        """
+        SELECT ts, dedupe_key
+        FROM tool_events
+        WHERE dedupe_key IS NOT NULL
+        """
+    )
+    seen: set[tuple[object, str]] = {
+        (ts, dedupe_key)
+        for ts, dedupe_key in _iter_cursor_rows(cursor)
+        if isinstance(dedupe_key, str)
+    }
+    cursor.execute(
+        """
+        SELECT ctid::text,
+               ts,
+               event_type,
+               tool_name,
+               ok,
+               duration_ms,
+               emotion_primary,
+               emotion_intensity,
+               numeric_metrics,
+               string_metrics,
+               params,
+               private,
+               message
+        FROM tool_events
+        WHERE dedupe_key IS NULL
+        ORDER BY ts ASC
+        """
+    )
+    raw_updates = build_tool_event_dedupe_updates(_iter_cursor_rows(cursor))
+    updates, duplicate_ctids = partition_dedupe_updates(raw_updates, existing=seen)
+    if dry_run:
+        return (len(updates), len(duplicate_ctids))
+    for ctid in duplicate_ctids:
+        cursor.execute(
+            """
+            DELETE FROM tool_events
+            WHERE ctid = %s::tid
+            """,
+            (ctid,),
+        )
+    for ctid, dedupe_key in updates:
+        cursor.execute(
+            """
+            UPDATE tool_events
+            SET dedupe_key = %s
+            WHERE ctid = %s::tid
+            """,
+            (dedupe_key, ctid),
+        )
+    return (len(updates), len(duplicate_ctids))
+
+
+def _backfill_log_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int, int]:
+    cursor.execute(
+        """
+        SELECT ts, dedupe_key
+        FROM log_events
+        WHERE dedupe_key IS NOT NULL
+        """
+    )
+    seen: set[tuple[object, str]] = {
+        (ts, dedupe_key)
+        for ts, dedupe_key in _iter_cursor_rows(cursor)
+        if isinstance(dedupe_key, str)
+    }
+    cursor.execute(
+        """
+        SELECT ctid::text,
+               ts,
+               level,
+               logger,
+               message,
+               private,
+               fields
+        FROM log_events
+        WHERE dedupe_key IS NULL
+        ORDER BY ts ASC
+        """
+    )
+    raw_updates = build_log_event_dedupe_updates(_iter_cursor_rows(cursor))
+    updates, duplicate_ctids = partition_dedupe_updates(raw_updates, existing=seen)
+    if dry_run:
+        return (len(updates), len(duplicate_ctids))
+    for ctid in duplicate_ctids:
+        cursor.execute(
+            """
+            DELETE FROM log_events
+            WHERE ctid = %s::tid
+            """,
+            (ctid,),
+        )
+    for ctid, dedupe_key in updates:
+        cursor.execute(
+            """
+            UPDATE log_events
+            SET dedupe_key = %s
+            WHERE ctid = %s::tid
+            """,
+            (dedupe_key, ctid),
+        )
+    return (len(updates), len(duplicate_ctids))
+
+
+def _delete_tool_event_duplicates(cursor: Any, *, dry_run: bool) -> int:
+    if dry_run:
+        cursor.execute(
+            """
+            WITH ranked AS (
+              SELECT row_number() OVER (PARTITION BY ts, dedupe_key ORDER BY ctid) AS row_num
+              FROM tool_events
+              WHERE dedupe_key IS NOT NULL
+            )
+            SELECT count(*)
+            FROM ranked
+            WHERE row_num > 1
+            """
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row and isinstance(row[0], int) else 0
+
+    cursor.execute(
+        """
+        WITH ranked AS (
+          SELECT ctid,
+                 row_number() OVER (PARTITION BY ts, dedupe_key ORDER BY ctid) AS row_num
+          FROM tool_events
+          WHERE dedupe_key IS NOT NULL
+        )
+        DELETE FROM tool_events AS target
+        USING ranked
+        WHERE target.ctid = ranked.ctid
+          AND ranked.row_num > 1
+        """
+    )
+    deleted = getattr(cursor, "rowcount", 0)
+    return int(deleted) if isinstance(deleted, int) and deleted > 0 else 0
+
+
+def _delete_log_event_duplicates(cursor: Any, *, dry_run: bool) -> int:
+    if dry_run:
+        cursor.execute(
+            """
+            WITH ranked AS (
+              SELECT row_number() OVER (PARTITION BY ts, dedupe_key ORDER BY ctid) AS row_num
+              FROM log_events
+              WHERE dedupe_key IS NOT NULL
+            )
+            SELECT count(*)
+            FROM ranked
+            WHERE row_num > 1
+            """
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row and isinstance(row[0], int) else 0
+
+    cursor.execute(
+        """
+        WITH ranked AS (
+          SELECT ctid,
+                 row_number() OVER (PARTITION BY ts, dedupe_key ORDER BY ctid) AS row_num
+          FROM log_events
+          WHERE dedupe_key IS NOT NULL
+        )
+        DELETE FROM log_events AS target
+        USING ranked
+        WHERE target.ctid = ranked.ctid
+          AND ranked.row_num > 1
+        """
+    )
+    deleted = getattr(cursor, "rowcount", 0)
+    return int(deleted) if isinstance(deleted, int) and deleted > 0 else 0
+
+
+def _initialize_checkpoints(cursor: Any, log_path: str, *, dry_run: bool) -> int:
+    count = 0
+    for resolved_path in _resolve_source_files(log_path):
+        stat = os.stat(resolved_path)
+        count += 1
+        if dry_run:
+            continue
+        cursor.execute(
+            """
+            INSERT INTO ingestion_checkpoints (path, inode, offset, updated_at)
+            VALUES (%s, %s, %s, now())
+            ON CONFLICT (path) DO UPDATE
+            SET inode = EXCLUDED.inode,
+                offset = EXCLUDED.offset,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (resolved_path, stat.st_ino, stat.st_size),
+        )
+    return count
+
+
+def run_cleanup(
+    *,
+    database_url: str,
+    log_path: str | None = None,
+    dry_run: bool = False,
+) -> CleanupStats:
+    SqlTelemetryStore(database_url, "redis://unused").initialize()
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            backfilled_tool_events, backfilled_tool_from_null = _backfill_tool_event_dedupe_keys(
+                cur, dry_run=dry_run
+            )
+            backfilled_log_events, backfilled_log_from_null = _backfill_log_event_dedupe_keys(
+                cur, dry_run=dry_run
+            )
+            deleted_tool_duplicates = backfilled_tool_from_null + _delete_tool_event_duplicates(
+                cur, dry_run=dry_run
+            )
+            deleted_log_duplicates = backfilled_log_from_null + _delete_log_event_duplicates(
+                cur, dry_run=dry_run
+            )
+            initialized_checkpoints = (
+                _initialize_checkpoints(cur, log_path, dry_run=dry_run) if log_path else 0
+            )
+        if not dry_run:
+            conn.commit()
+
+    return CleanupStats(
+        backfilled_tool_events=backfilled_tool_events,
+        backfilled_log_events=backfilled_log_events,
+        deleted_tool_duplicates=deleted_tool_duplicates,
+        deleted_log_duplicates=deleted_log_duplicates,
+        initialized_checkpoints=initialized_checkpoints,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill dedupe keys and remove replay duplicates"
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.getenv("DASHBOARD_DATABASE_URL"),
+        help="TimescaleDB/PostgreSQL connection string",
+    )
+    parser.add_argument(
+        "--log-path",
+        default=os.getenv("DASHBOARD_LOG_PATH"),
+        help="Optional file/glob used to initialize ingestion checkpoints to current EOF",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report changes without writing")
+    args = parser.parse_args()
+
+    database_url = args.database_url
+    if not isinstance(database_url, str) or not database_url:
+        parser.error("database URL is required via --database-url or DASHBOARD_DATABASE_URL")
+
+    stats = run_cleanup(
+        database_url=database_url,
+        log_path=args.log_path if isinstance(args.log_path, str) and args.log_path else None,
+        dry_run=bool(args.dry_run),
+    )
+    print(json.dumps(asdict(stats), ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/src/ego_dashboard/dedupe_telemetry.py
+++ b/dashboard/src/ego_dashboard/dedupe_telemetry.py
@@ -306,11 +306,11 @@ def _initialize_checkpoints(cursor: Any, log_path: str, *, dry_run: bool) -> int
             continue
         cursor.execute(
             """
-            INSERT INTO ingestion_checkpoints (path, inode, offset, updated_at)
+            INSERT INTO ingestion_checkpoints (path, inode, byte_offset, updated_at)
             VALUES (%s, %s, %s, now())
             ON CONFLICT (path) DO UPDATE
             SET inode = EXCLUDED.inode,
-                offset = EXCLUDED.offset,
+                byte_offset = EXCLUDED.byte_offset,
                 updated_at = EXCLUDED.updated_at
             """,
             (resolved_path, stat.st_ino, stat.st_size),

--- a/dashboard/src/ego_dashboard/dedupe_telemetry.py
+++ b/dashboard/src/ego_dashboard/dedupe_telemetry.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 import psycopg
+from psycopg.errors import UniqueViolation
 
 from ego_dashboard.ingestor import _resolve_source_files
 from ego_dashboard.models import DashboardEvent, LogEvent
@@ -105,8 +106,8 @@ def partition_dedupe_updates(
     rows: list[tuple[str, object, str]],
     *,
     existing: set[tuple[object, str]] | None = None,
-) -> tuple[list[tuple[str, str]], list[str]]:
-    updates: list[tuple[str, str]] = []
+) -> tuple[list[tuple[str, object, str]], list[str]]:
+    updates: list[tuple[str, object, str]] = []
     duplicate_ctids: list[str] = []
     seen = set(existing or set())
     for ctid, ts, dedupe_key in rows:
@@ -115,8 +116,63 @@ def partition_dedupe_updates(
             duplicate_ctids.append(ctid)
             continue
         seen.add(identity)
-        updates.append((ctid, dedupe_key))
+        updates.append((ctid, ts, dedupe_key))
     return updates, duplicate_ctids
+
+
+def _apply_backfill_updates(
+    cursor: Any,
+    *,
+    table: str,
+    updates: list[tuple[str, object, str]],
+) -> tuple[int, int]:
+    updated_rows = 0
+    deleted_duplicates = 0
+
+    for ctid, ts, dedupe_key in updates:
+        cursor.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE ctid = %s::tid
+              AND EXISTS (
+                SELECT 1
+                FROM {table} AS existing
+                WHERE existing.ts = %s
+                  AND existing.dedupe_key = %s
+              )
+            """,
+            (ctid, ts, dedupe_key),
+        )
+        deleted_now = getattr(cursor, "rowcount", 0)
+        if isinstance(deleted_now, int) and deleted_now > 0:
+            deleted_duplicates += deleted_now
+            continue
+
+        try:
+            cursor.execute(
+                f"""
+                UPDATE {table}
+                SET dedupe_key = %s
+                WHERE ctid = %s::tid
+                """,
+                (dedupe_key, ctid),
+            )
+        except UniqueViolation:
+            cursor.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE ctid = %s::tid
+                """,
+                (ctid,),
+            )
+            deleted_duplicates += 1
+            continue
+
+        updated_now = getattr(cursor, "rowcount", 0)
+        if isinstance(updated_now, int) and updated_now > 0:
+            updated_rows += updated_now
+
+    return updated_rows, deleted_duplicates
 
 
 def _backfill_tool_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int, int]:
@@ -164,16 +220,10 @@ def _backfill_tool_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int
             """,
             (ctid,),
         )
-    for ctid, dedupe_key in updates:
-        cursor.execute(
-            """
-            UPDATE tool_events
-            SET dedupe_key = %s
-            WHERE ctid = %s::tid
-            """,
-            (dedupe_key, ctid),
-        )
-    return (len(updates), len(duplicate_ctids))
+    updated_rows, deleted_on_conflict = _apply_backfill_updates(
+        cursor, table="tool_events", updates=updates
+    )
+    return (updated_rows, len(duplicate_ctids) + deleted_on_conflict)
 
 
 def _backfill_log_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int, int]:
@@ -215,16 +265,10 @@ def _backfill_log_event_dedupe_keys(cursor: Any, *, dry_run: bool) -> tuple[int,
             """,
             (ctid,),
         )
-    for ctid, dedupe_key in updates:
-        cursor.execute(
-            """
-            UPDATE log_events
-            SET dedupe_key = %s
-            WHERE ctid = %s::tid
-            """,
-            (dedupe_key, ctid),
-        )
-    return (len(updates), len(duplicate_ctids))
+    updated_rows, deleted_on_conflict = _apply_backfill_updates(
+        cursor, table="log_events", updates=updates
+    )
+    return (updated_rows, len(duplicate_ctids) + deleted_on_conflict)
 
 
 def _delete_tool_event_duplicates(cursor: Any, *, dry_run: bool) -> int:

--- a/dashboard/src/ego_dashboard/dedupe_telemetry.py
+++ b/dashboard/src/ego_dashboard/dedupe_telemetry.py
@@ -126,28 +126,37 @@ def _apply_backfill_updates(
     table: str,
     updates: list[tuple[str, object, str]],
 ) -> tuple[int, int]:
+    if table not in {"tool_events", "log_events"}:
+        raise ValueError(f"unsupported table: {table}")
+
     updated_rows = 0
     deleted_duplicates = 0
 
     for ctid, ts, dedupe_key in updates:
         cursor.execute(
             f"""
-            DELETE FROM {table}
-            WHERE ctid = %s::tid
-              AND EXISTS (
-                SELECT 1
-                FROM {table} AS existing
-                WHERE existing.ts = %s
-                  AND existing.dedupe_key = %s
-              )
+            SELECT 1
+            FROM {table}
+            WHERE ts = %s
+              AND dedupe_key = %s
+            LIMIT 1
             """,
-            (ctid, ts, dedupe_key),
+            (ts, dedupe_key),
         )
-        deleted_now = getattr(cursor, "rowcount", 0)
-        if isinstance(deleted_now, int) and deleted_now > 0:
-            deleted_duplicates += deleted_now
+        if cursor.fetchone() is not None:
+            cursor.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE ctid = %s::tid
+                """,
+                (ctid,),
+            )
+            deleted_now = getattr(cursor, "rowcount", 0)
+            if isinstance(deleted_now, int) and deleted_now > 0:
+                deleted_duplicates += deleted_now
             continue
 
+        cursor.execute("SAVEPOINT dedupe_backfill_row")
         try:
             cursor.execute(
                 f"""
@@ -157,7 +166,9 @@ def _apply_backfill_updates(
                 """,
                 (dedupe_key, ctid),
             )
+            updated_now = getattr(cursor, "rowcount", 0)
         except UniqueViolation:
+            cursor.execute("ROLLBACK TO SAVEPOINT dedupe_backfill_row")
             cursor.execute(
                 f"""
                 DELETE FROM {table}
@@ -166,9 +177,10 @@ def _apply_backfill_updates(
                 (ctid,),
             )
             deleted_duplicates += 1
+            cursor.execute("RELEASE SAVEPOINT dedupe_backfill_row")
             continue
+        cursor.execute("RELEASE SAVEPOINT dedupe_backfill_row")
 
-        updated_now = getattr(cursor, "rowcount", 0)
         if isinstance(updated_now, int) and updated_now > 0:
             updated_rows += updated_now
 

--- a/dashboard/src/ego_dashboard/ingestor.py
+++ b/dashboard/src/ego_dashboard/ingestor.py
@@ -9,7 +9,7 @@ import threading
 import time
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from ego_dashboard.constants import DESIRE_METRIC_KEYS
 from ego_dashboard.models import DashboardEvent, LogEvent
@@ -118,6 +118,13 @@ class IngestStoreProtocol(Protocol):
     def ingest(self, event: DashboardEvent) -> None: ...
 
     def ingest_log(self, event: LogEvent) -> None: ...
+
+
+@runtime_checkable
+class CheckpointStoreProtocol(Protocol):
+    def load_checkpoint(self, path: str) -> tuple[int, int] | None: ...
+
+    def save_checkpoint(self, path: str, inode: int, offset: int) -> None: ...
 
 
 class EgoMcpLogProjector:
@@ -380,6 +387,17 @@ def _resolve_source_files(path_or_glob: str) -> list[str]:
     return [path_or_glob] if os.path.isfile(path_or_glob) else []
 
 
+def _load_checkpoint(store: IngestStoreProtocol, path: str) -> tuple[int, int] | None:
+    if isinstance(store, CheckpointStoreProtocol):
+        return store.load_checkpoint(path)
+    return None
+
+
+def _save_checkpoint(store: IngestStoreProtocol, path: str, inode: int, offset: int) -> None:
+    if isinstance(store, CheckpointStoreProtocol):
+        store.save_checkpoint(path, inode, offset)
+
+
 def tail_jsonl_file(
     path: str,
     store: IngestStoreProtocol,
@@ -390,6 +408,7 @@ def tail_jsonl_file(
     inodes: dict[str, int] = {}
     positions: dict[str, int] = {}
     projectors: dict[str, EgoMcpLogProjector] = {}
+    announced_resumes: set[str] = set()
 
     while stop_event is None or not stop_event.is_set():
         selected_paths = _resolve_source_files(path)
@@ -399,6 +418,7 @@ def tail_jsonl_file(
             inodes.clear()
             positions.clear()
             projectors.clear()
+            announced_resumes.clear()
             if stop_event is not None and stop_event.wait(poll_seconds):
                 break
             if stop_event is None:
@@ -411,14 +431,22 @@ def tail_jsonl_file(
                 positions.pop(stale_path, None)
                 inodes.pop(stale_path, None)
                 projectors.pop(stale_path, None)
+                announced_resumes.discard(stale_path)
 
         for selected_path in selected_paths:
             if stop_event is not None and stop_event.is_set():
                 break
+            if selected_path not in positions:
+                checkpoint = _load_checkpoint(store, selected_path)
+                if checkpoint is not None:
+                    checkpoint_inode, checkpoint_offset = checkpoint
+                    inodes[selected_path] = checkpoint_inode
+                    positions[selected_path] = checkpoint_offset
             stat = os.stat(selected_path)
             current_inode = inodes.get(selected_path)
             position = positions.get(selected_path, 0)
             projector = projectors.setdefault(selected_path, EgoMcpLogProjector())
+            checkpoint_changed = False
 
             if current_inode != stat.st_ino or stat.st_size < position:
                 inodes[selected_path] = stat.st_ino
@@ -426,7 +454,12 @@ def tail_jsonl_file(
                 positions[selected_path] = 0
                 projectors[selected_path] = EgoMcpLogProjector()
                 projector = projectors[selected_path]
+                announced_resumes.discard(selected_path)
+                checkpoint_changed = True
                 LOGGER.info("opened source file: %s", selected_path)
+            elif position > 0 and selected_path not in announced_resumes:
+                LOGGER.info("resuming source file: %s at offset=%s", selected_path, position)
+                announced_resumes.add(selected_path)
 
             with open(selected_path, encoding="utf-8") as handle:
                 handle.seek(position)
@@ -437,8 +470,11 @@ def tail_jsonl_file(
                     if line == "":
                         break
                     ingest_jsonl_line(line, store, projector=projector)
-                positions[selected_path] = handle.tell()
+                new_position = handle.tell()
+                positions[selected_path] = new_position
                 inodes[selected_path] = stat.st_ino
+                if checkpoint_changed or new_position != position:
+                    _save_checkpoint(store, selected_path, stat.st_ino, new_position)
 
         if stop_event is not None:
             if stop_event.wait(poll_seconds):

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -171,7 +171,7 @@ class SqlTelemetryStore:
                     CREATE TABLE IF NOT EXISTS ingestion_checkpoints (
                       path TEXT PRIMARY KEY,
                       inode BIGINT NOT NULL,
-                      offset BIGINT NOT NULL,
+                      byte_offset BIGINT NOT NULL,
                       updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
                     )
                     """
@@ -249,7 +249,7 @@ class SqlTelemetryStore:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT inode, offset
+                    SELECT inode, byte_offset
                     FROM ingestion_checkpoints
                     WHERE path = %s
                     """,
@@ -268,11 +268,11 @@ class SqlTelemetryStore:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO ingestion_checkpoints (path, inode, offset, updated_at)
+                    INSERT INTO ingestion_checkpoints (path, inode, byte_offset, updated_at)
                     VALUES (%s, %s, %s, now())
                     ON CONFLICT (path) DO UPDATE
                     SET inode = EXCLUDED.inode,
-                        offset = EXCLUDED.offset,
+                        byte_offset = EXCLUDED.byte_offset,
                         updated_at = EXCLUDED.updated_at
                     """,
                     (path, inode, offset),

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -9,6 +9,7 @@ from redis import Redis
 
 from ego_dashboard.constants import DESIRE_METRIC_KEYS
 from ego_dashboard.models import DashboardEvent, LogEvent
+from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
 
 
 def _escape_ilike_pattern(value: str) -> str:
@@ -49,6 +50,49 @@ def _fallback_notion_confidence(
     return None
 
 
+def _tool_name_from_fields(fields: object) -> str | None:
+    if not isinstance(fields, dict):
+        return None
+    raw = fields.get("tool_name")
+    return raw if isinstance(raw, str) and raw else None
+
+
+def _dense_usage_rows(
+    rows: list[tuple[datetime, str, int]],
+    start: datetime,
+    end: datetime,
+    bucket: str,
+) -> list[dict[str, object]]:
+    if not rows:
+        return []
+
+    bucket_delta = _bucket_to_timedelta(bucket)
+    tool_names = sorted({tool_name for _, tool_name, _ in rows})
+    by_ts: dict[str, dict[str, object]] = {}
+    for bucket_ts, tool_name, count in rows:
+        aware = bucket_ts if bucket_ts.tzinfo is not None else bucket_ts.replace(tzinfo=UTC)
+        key = aware.astimezone(UTC).isoformat()
+        row = by_ts.get(key)
+        if row is None:
+            row = {"ts": key}
+            by_ts[key] = row
+        row[tool_name] = int(count)
+
+    first_bucket = _bucket_floor(start, bucket_delta)
+    last_bucket = _bucket_floor(end, bucket_delta)
+    cursor = first_bucket
+    dense_rows: list[dict[str, object]] = []
+    while cursor <= last_bucket:
+        key = cursor.isoformat()
+        row = dict(by_ts.get(key, {"ts": key}))
+        for tool_name in tool_names:
+            value = row.get(tool_name, 0)
+            row[tool_name] = int(value) if isinstance(value, (int, float)) else 0
+        dense_rows.append(row)
+        cursor += bucket_delta
+    return dense_rows
+
+
 class SqlTelemetryStore:
     def __init__(self, database_url: str, redis_url: str) -> None:
         self._db_url = database_url
@@ -72,14 +116,25 @@ class SqlTelemetryStore:
                       string_metrics JSONB NOT NULL,
                       params JSONB NOT NULL,
                       private BOOLEAN NOT NULL,
-                      message TEXT
+                      message TEXT,
+                      dedupe_key TEXT
                     )
+                    """
+                )
+                cur.execute(
+                    """
+                    ALTER TABLE tool_events
+                    ADD COLUMN IF NOT EXISTS dedupe_key TEXT
                     """
                 )
                 cur.execute("SELECT create_hypertable('tool_events', 'ts', if_not_exists => TRUE)")
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_tool_events_tool_name_ts "
                     "ON tool_events (tool_name, ts DESC)"
+                )
+                cur.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tool_events_ts_dedupe "
+                    "ON tool_events (ts, dedupe_key) WHERE dedupe_key IS NOT NULL"
                 )
                 cur.execute(
                     """
@@ -89,7 +144,8 @@ class SqlTelemetryStore:
                       logger TEXT NOT NULL,
                       message TEXT NOT NULL,
                       private BOOLEAN NOT NULL,
-                      fields JSONB NOT NULL DEFAULT '{}'::jsonb
+                      fields JSONB NOT NULL DEFAULT '{}'::jsonb,
+                      dedupe_key TEXT
                     )
                     """
                 )
@@ -99,18 +155,43 @@ class SqlTelemetryStore:
                     ADD COLUMN IF NOT EXISTS fields JSONB NOT NULL DEFAULT '{}'::jsonb
                     """
                 )
+                cur.execute(
+                    """
+                    ALTER TABLE log_events
+                    ADD COLUMN IF NOT EXISTS dedupe_key TEXT
+                    """
+                )
                 cur.execute("SELECT create_hypertable('log_events', 'ts', if_not_exists => TRUE)")
+                cur.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_log_events_ts_dedupe "
+                    "ON log_events (ts, dedupe_key) WHERE dedupe_key IS NOT NULL"
+                )
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS ingestion_checkpoints (
+                      path TEXT PRIMARY KEY,
+                      inode BIGINT NOT NULL,
+                      offset BIGINT NOT NULL,
+                      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
+                )
             conn.commit()
 
     def ingest(self, event: DashboardEvent) -> None:
+        dedupe_key = dashboard_event_dedupe_key(event)
         with psycopg.connect(self._db_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
                     INSERT INTO tool_events (
                       ts, event_type, tool_name, ok, duration_ms, emotion_primary,
-                      emotion_intensity, numeric_metrics, string_metrics, params, private, message
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
+                      emotion_intensity, numeric_metrics, string_metrics, params, private,
+                      message, dedupe_key
+                    ) VALUES (
+                      %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s, %s
+                    )
+                    ON CONFLICT (ts, dedupe_key) WHERE dedupe_key IS NOT NULL DO NOTHING
                     """,
                     (
                         event.ts,
@@ -125,6 +206,7 @@ class SqlTelemetryStore:
                         json.dumps(event.params),
                         event.private,
                         event.message,
+                        dedupe_key,
                     ),
                 )
             conn.commit()
@@ -132,12 +214,23 @@ class SqlTelemetryStore:
 
     def ingest_log(self, event: LogEvent) -> None:
         masked = "REDACTED" if event.private else event.message
+        dedupe_key = log_event_dedupe_key(
+            LogEvent(
+                ts=event.ts,
+                level=event.level,
+                logger=event.logger,
+                message=masked,
+                private=event.private,
+                fields=event.fields,
+            )
+        )
         with psycopg.connect(self._db_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO log_events (ts, level, logger, message, private, fields)
-                    VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+                    INSERT INTO log_events (ts, level, logger, message, private, fields, dedupe_key)
+                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s)
+                    ON CONFLICT (ts, dedupe_key) WHERE dedupe_key IS NOT NULL DO NOTHING
                     """,
                     (
                         event.ts,
@@ -146,53 +239,91 @@ class SqlTelemetryStore:
                         masked,
                         event.private,
                         json.dumps(event.fields),
+                        dedupe_key,
                     ),
+                )
+            conn.commit()
+
+    def load_checkpoint(self, path: str) -> tuple[int, int] | None:
+        with psycopg.connect(self._db_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT inode, offset
+                    FROM ingestion_checkpoints
+                    WHERE path = %s
+                    """,
+                    (path,),
+                )
+                row = cur.fetchone()
+        if row is None:
+            return None
+        inode, offset = row
+        if not isinstance(inode, int) or not isinstance(offset, int):
+            return None
+        return (inode, offset)
+
+    def save_checkpoint(self, path: str, inode: int, offset: int) -> None:
+        with psycopg.connect(self._db_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO ingestion_checkpoints (path, inode, offset, updated_at)
+                    VALUES (%s, %s, %s, now())
+                    ON CONFLICT (path) DO UPDATE
+                    SET inode = EXCLUDED.inode,
+                        offset = EXCLUDED.offset,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    (path, inode, offset),
                 )
             conn.commit()
 
     def tool_usage(self, start: datetime, end: datetime, bucket: str) -> list[dict[str, object]]:
         bucket_size = _bucket_to_sql(bucket)
-        bucket_delta = _bucket_to_timedelta(bucket)
         with psycopg.connect(self._db_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT time_bucket(%s::interval, ts) AS b, tool_name, count(*)
-                    FROM tool_events
+                    SELECT time_bucket(%s::interval, ts) AS b,
+                           fields ->> 'tool_name' AS tool_name,
+                           count(*)
+                    FROM log_events
                     WHERE ts >= %s AND ts <= %s
+                      AND message = 'Tool invocation'
+                      AND fields ? 'tool_name'
                     GROUP BY b, tool_name
                     ORDER BY b ASC
                     """,
                     (bucket_size, start, end),
                 )
                 rows = cur.fetchall()
-        if not rows:
-            return []
+                if rows:
+                    log_rows = [
+                        (bucket_ts, str(tool_name), int(count))
+                        for bucket_ts, tool_name, count in rows
+                        if isinstance(bucket_ts, datetime) and isinstance(tool_name, str)
+                    ]
+                    return _dense_usage_rows(log_rows, start, end, bucket)
 
-        tool_names = sorted({str(tool_name) for _, tool_name, _ in rows})
-        by_ts: dict[str, dict[str, object]] = {}
-        for b, tool_name, count in rows:
-            bucket_ts = b if b.tzinfo is not None else b.replace(tzinfo=UTC)
-            key = bucket_ts.astimezone(UTC).isoformat()
-            row = by_ts.get(key)
-            if row is None:
-                row = {"ts": key}
-                by_ts[key] = row
-            row[str(tool_name)] = int(count)
-
-        first_bucket = _bucket_floor(start, bucket_delta)
-        last_bucket = _bucket_floor(end, bucket_delta)
-        cursor = first_bucket
-        dense_rows: list[dict[str, object]] = []
-        while cursor <= last_bucket:
-            key = cursor.isoformat()
-            row = dict(by_ts.get(key, {"ts": key}))
-            for tool_name in tool_names:
-                value = row.get(tool_name, 0)
-                row[tool_name] = int(value) if isinstance(value, (int, float)) else 0
-            dense_rows.append(row)
-            cursor += bucket_delta
-        return dense_rows
+                cur.execute(
+                    """
+                    SELECT time_bucket(%s::interval, ts) AS b, tool_name, count(*)
+                    FROM tool_events
+                    WHERE ts >= %s AND ts <= %s
+                      AND event_type IN ('tool_call_completed', 'tool_call_failed')
+                    GROUP BY b, tool_name
+                    ORDER BY b ASC
+                    """,
+                    (bucket_size, start, end),
+                )
+                fallback_rows = cur.fetchall()
+        typed_rows = [
+            (bucket_ts, str(tool_name), int(count))
+            for bucket_ts, tool_name, count in fallback_rows
+            if isinstance(bucket_ts, datetime) and isinstance(tool_name, str)
+        ]
+        return _dense_usage_rows(typed_rows, start, end, bucket)
 
     def metric_history(
         self, key: str, start: datetime, end: datetime, bucket: str
@@ -484,6 +615,7 @@ class SqlTelemetryStore:
                            sum(CASE WHEN ok = false THEN 1 ELSE 0 END)
                     FROM tool_events
                     WHERE ts >= %s - interval '1 minute' AND ts <= %s
+                      AND event_type IN ('tool_call_completed', 'tool_call_failed')
                     """,
                     (latest_ts, latest_ts),
                 )
@@ -494,6 +626,7 @@ class SqlTelemetryStore:
                            sum(CASE WHEN ok = false THEN 1 ELSE 0 END)
                     FROM tool_events
                     WHERE ts >= %s - interval '24 hours' AND ts <= %s
+                      AND event_type IN ('tool_call_completed', 'tool_call_failed')
                     """,
                     (latest_ts, latest_ts),
                 )

--- a/dashboard/src/ego_dashboard/store.py
+++ b/dashboard/src/ego_dashboard/store.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 
 from ego_dashboard.constants import DESIRE_METRIC_KEYS
 from ego_dashboard.models import DashboardEvent, LogEvent
+from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
 
 _BUCKETS = {"1m": timedelta(minutes=1), "5m": timedelta(minutes=5), "15m": timedelta(minutes=15)}
 
@@ -15,20 +16,50 @@ class TelemetryStore:
     def __init__(self) -> None:
         self._events: list[DashboardEvent] = []
         self._logs: list[LogEvent] = []
+        self._event_keys: set[tuple[datetime, str]] = set()
+        self._log_keys: set[tuple[datetime, str]] = set()
+        self._checkpoints: dict[str, tuple[int, int]] = {}
 
     def ingest(self, event: DashboardEvent) -> None:
+        key = (event.ts, dashboard_event_dedupe_key(event))
+        if key in self._event_keys:
+            return
+        self._event_keys.add(key)
         self._events.append(event)
         self._events.sort(key=lambda item: item.ts)
 
     def ingest_log(self, event: LogEvent) -> None:
+        key = (event.ts, log_event_dedupe_key(event))
+        if key in self._log_keys:
+            return
+        self._log_keys.add(key)
         self._logs.append(event)
         self._logs.sort(key=lambda item: item.ts)
+
+    def load_checkpoint(self, path: str) -> tuple[int, int] | None:
+        return self._checkpoints.get(path)
+
+    def save_checkpoint(self, path: str, inode: int, offset: int) -> None:
+        self._checkpoints[path] = (inode, offset)
 
     def _bucket_delta(self, bucket: str) -> timedelta:
         return _BUCKETS.get(bucket, timedelta(minutes=1))
 
     def _filtered(self, start: datetime, end: datetime) -> list[DashboardEvent]:
         return [item for item in self._events if start <= item.ts <= end]
+
+    def _terminal_events(self, start: datetime, end: datetime) -> list[DashboardEvent]:
+        return [
+            item
+            for item in self._events
+            if start <= item.ts <= end
+            and item.event_type in {"tool_call_completed", "tool_call_failed"}
+        ]
+
+    @staticmethod
+    def _invocation_tool_name(log: LogEvent) -> str | None:
+        raw = log.fields.get("tool_name")
+        return raw if isinstance(raw, str) and raw else None
 
     def _latest_numeric_metrics(self, keys: tuple[str, ...]) -> dict[str, float]:
         if not self._events:
@@ -79,16 +110,49 @@ class TelemetryStore:
         return rows
 
     def tool_usage(self, start: datetime, end: datetime, bucket: str) -> list[dict[str, object]]:
-        events = self._filtered(start, end)
+        invocations = [
+            log
+            for log in self._logs
+            if start <= log.ts <= end
+            and log.message == "Tool invocation"
+            and self._invocation_tool_name(log) is not None
+        ]
+        if invocations:
+            tool_names = sorted(
+                {
+                    tool_name
+                    for log in invocations
+                    if (tool_name := self._invocation_tool_name(log)) is not None
+                }
+            )
+            log_usage_rows: list[dict[str, object]] = []
+            delta = self._bucket_delta(bucket)
+            cursor = start
+            while cursor < end:
+                bucket_end = cursor + delta
+                log_counts: Counter[str] = Counter(
+                    tool_name
+                    for log in invocations
+                    if cursor <= log.ts < bucket_end
+                    if (tool_name := self._invocation_tool_name(log)) is not None
+                )
+                row: dict[str, object] = {"ts": cursor.isoformat()}
+                for tool_name in tool_names:
+                    row[tool_name] = int(log_counts.get(tool_name, 0))
+                log_usage_rows.append(row)
+                cursor = bucket_end
+            return log_usage_rows
+
+        events = self._terminal_events(start, end)
         tool_names = sorted({ev.tool_name for ev in events})
-        rows: list[dict[str, object]] = []
+        event_usage_rows: list[dict[str, object]] = []
         for at, grouped in self._bucket_events(events, start, end, bucket):
-            counts: dict[str, int] = Counter(ev.tool_name for ev in grouped)
-            row: dict[str, object] = {"ts": at.isoformat()}
+            event_counts: dict[str, int] = Counter(ev.tool_name for ev in grouped)
+            row = {"ts": at.isoformat()}
             for tool_name in tool_names:
-                row[tool_name] = int(counts.get(tool_name, 0))
-            rows.append(row)
-        return rows
+                row[tool_name] = int(event_counts.get(tool_name, 0))
+            event_usage_rows.append(row)
+        return event_usage_rows
 
     def metric_history(
         self, key: str, start: datetime, end: datetime, bucket: str
@@ -221,8 +285,12 @@ class TelemetryStore:
         window_24h_start = latest.ts - timedelta(hours=24)
         recent = [ev for ev in self._events if ev.ts >= window_start]
         recent_24h = [ev for ev in self._events if ev.ts >= window_24h_start]
-        errors = [ev for ev in recent if not ev.ok]
-        errors_24h = [ev for ev in recent_24h if not ev.ok]
+        terminal_recent = [
+            ev for ev in recent if ev.event_type in {"tool_call_completed", "tool_call_failed"}
+        ]
+        terminal_recent_24h = [
+            ev for ev in recent_24h if ev.event_type in {"tool_call_completed", "tool_call_failed"}
+        ]
         latest_payload = latest.model_dump(mode="json")
         if latest.private:
             latest_payload["message"] = "REDACTED"
@@ -273,28 +341,38 @@ class TelemetryStore:
         invocation_count = sum(
             1
             for log in log_window
-            if log.message == "Tool invocation" and "tool_name" in log.fields
+            if log.message == "Tool invocation" and self._invocation_tool_name(log) is not None
         )
         failure_count = sum(1 for log in log_window if log.message == "Tool execution failed")
         invocation_count_24h = sum(
             1
             for log in log_window_24h
-            if log.message == "Tool invocation" and "tool_name" in log.fields
+            if log.message == "Tool invocation" and self._invocation_tool_name(log) is not None
         )
         failure_count_24h = sum(
             1 for log in log_window_24h if log.message == "Tool execution failed"
         )
-        tool_calls_per_min = invocation_count if invocation_count > 0 else len(recent)
+        tool_calls_per_min = invocation_count if invocation_count > 0 else len(terminal_recent)
         error_rate = (
             (failure_count / invocation_count)
             if invocation_count > 0
-            else (len(errors) / len(recent) if recent else 0.0)
+            else (
+                sum(1 for ev in terminal_recent if not ev.ok) / len(terminal_recent)
+                if terminal_recent
+                else 0.0
+            )
         )
-        tool_calls_24h = invocation_count_24h if invocation_count_24h > 0 else len(recent_24h)
+        tool_calls_24h = (
+            invocation_count_24h if invocation_count_24h > 0 else len(terminal_recent_24h)
+        )
         error_rate_24h = (
             (failure_count_24h / invocation_count_24h)
             if invocation_count_24h > 0
-            else (len(errors_24h) / len(recent_24h) if recent_24h else 0.0)
+            else (
+                sum(1 for ev in terminal_recent_24h if not ev.ok) / len(terminal_recent_24h)
+                if terminal_recent_24h
+                else 0.0
+            )
         )
         desire_metrics = self._latest_desire_metrics()
         latest_fixed_desires = {

--- a/dashboard/src/ego_dashboard/telemetry_identity.py
+++ b/dashboard/src/ego_dashboard/telemetry_identity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from ego_dashboard.models import DashboardEvent, LogEvent
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def dashboard_event_dedupe_key(event: DashboardEvent) -> str:
+    payload = {
+        "event_type": event.event_type,
+        "tool_name": event.tool_name,
+        "ok": event.ok,
+        "duration_ms": event.duration_ms,
+        "emotion_primary": event.emotion_primary,
+        "emotion_intensity": event.emotion_intensity,
+        "numeric_metrics": event.numeric_metrics,
+        "string_metrics": event.string_metrics,
+        "params": event.params,
+        "private": event.private,
+        "message": event.message,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def log_event_dedupe_key(event: LogEvent) -> str:
+    payload = {
+        "level": event.level.upper(),
+        "logger": event.logger,
+        "message": event.message,
+        "private": event.private,
+        "fields": event.fields,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()

--- a/dashboard/tests/test_dedupe_telemetry.py
+++ b/dashboard/tests/test_dedupe_telemetry.py
@@ -114,15 +114,21 @@ def test_apply_backfill_updates_deletes_rows_that_conflict_during_update() -> No
             self.rowcount = 0
             self.updated: list[str] = []
             self.deleted: list[str] = []
+            self.last_select_result: tuple[int] | None = None
 
         def execute(self, query: object, params: object | None = None) -> None:
             sql = str(query)
             tuple_params = params if isinstance(params, tuple) else ()
-            if sql.lstrip().startswith("DELETE FROM tool_events") and "EXISTS" in sql:
-                ctid = str(tuple_params[0])
-                self.rowcount = 1 if ctid == "(0,1)" else 0
-                if self.rowcount == 1:
-                    self.deleted.append(ctid)
+            if sql.lstrip().startswith("SELECT 1"):
+                dedupe_key = str(tuple_params[1])
+                self.last_select_result = (1,) if dedupe_key == "existing" else None
+                self.rowcount = 1 if self.last_select_result is not None else 0
+                return
+            if sql.lstrip().startswith("SAVEPOINT") or sql.lstrip().startswith("RELEASE SAVEPOINT"):
+                self.rowcount = 0
+                return
+            if sql.lstrip().startswith("ROLLBACK TO SAVEPOINT"):
+                self.rowcount = 0
                 return
             if sql.lstrip().startswith("UPDATE tool_events"):
                 ctid = str(tuple_params[1])
@@ -137,6 +143,9 @@ def test_apply_backfill_updates_deletes_rows_that_conflict_during_update() -> No
                 self.deleted.append(ctid)
                 return
             self.rowcount = 0
+
+        def fetchone(self) -> tuple[int] | None:
+            return self.last_select_result
 
     cursor = _Cursor()
     ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)

--- a/dashboard/tests/test_dedupe_telemetry.py
+++ b/dashboard/tests/test_dedupe_telemetry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ego_dashboard.dedupe_telemetry import (
+    build_log_event_dedupe_updates,
+    build_tool_event_dedupe_updates,
+    partition_dedupe_updates,
+)
+
+
+def test_partition_tool_event_updates_drops_only_exact_duplicates() -> None:
+    ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    rows: list[tuple[object, ...]] = [
+        (
+            "(0,1)",
+            ts,
+            "tool_call_completed",
+            "remember",
+            True,
+            10,
+            None,
+            None,
+            {},
+            {},
+            {},
+            False,
+            "ok",
+        ),
+        (
+            "(0,2)",
+            ts,
+            "tool_call_completed",
+            "remember",
+            True,
+            10,
+            None,
+            None,
+            {},
+            {},
+            {},
+            False,
+            "ok",
+        ),
+        (
+            "(0,3)",
+            ts,
+            "tool_call_failed",
+            "remember",
+            False,
+            10,
+            None,
+            None,
+            {},
+            {},
+            {},
+            False,
+            "ng",
+        ),
+    ]
+
+    updates, duplicates = partition_dedupe_updates(build_tool_event_dedupe_updates(rows))
+
+    assert len(updates) == 2
+    assert duplicates == ["(0,2)"]
+
+
+def test_partition_log_event_updates_preserves_distinct_rows() -> None:
+    ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    rows: list[tuple[object, ...]] = [
+        (
+            "(1,1)",
+            ts,
+            "INFO",
+            "ego_mcp.server",
+            "Tool invocation",
+            False,
+            {"tool_name": "remember"},
+        ),
+        (
+            "(1,2)",
+            ts,
+            "INFO",
+            "ego_mcp.server",
+            "Tool invocation",
+            False,
+            {"tool_name": "remember"},
+        ),
+        (
+            "(1,3)",
+            ts,
+            "ERROR",
+            "ego_mcp.server",
+            "Tool execution failed",
+            False,
+            {"tool_name": "remember"},
+        ),
+    ]
+
+    updates, duplicates = partition_dedupe_updates(build_log_event_dedupe_updates(rows))
+
+    assert len(updates) == 2
+    assert duplicates == ["(1,2)"]

--- a/dashboard/tests/test_dedupe_telemetry.py
+++ b/dashboard/tests/test_dedupe_telemetry.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from psycopg.errors import UniqueViolation
+
 from ego_dashboard.dedupe_telemetry import (
+    _apply_backfill_updates,
     build_log_event_dedupe_updates,
     build_tool_event_dedupe_updates,
     partition_dedupe_updates,
@@ -63,6 +66,8 @@ def test_partition_tool_event_updates_drops_only_exact_duplicates() -> None:
 
     assert len(updates) == 2
     assert duplicates == ["(0,2)"]
+    assert updates[0][0] == "(0,1)"
+    assert updates[1][0] == "(0,3)"
 
 
 def test_partition_log_event_updates_preserves_distinct_rows() -> None:
@@ -101,3 +106,51 @@ def test_partition_log_event_updates_preserves_distinct_rows() -> None:
 
     assert len(updates) == 2
     assert duplicates == ["(1,2)"]
+
+
+def test_apply_backfill_updates_deletes_rows_that_conflict_during_update() -> None:
+    class _Cursor:
+        def __init__(self) -> None:
+            self.rowcount = 0
+            self.updated: list[str] = []
+            self.deleted: list[str] = []
+
+        def execute(self, query: object, params: object | None = None) -> None:
+            sql = str(query)
+            tuple_params = params if isinstance(params, tuple) else ()
+            if sql.lstrip().startswith("DELETE FROM tool_events") and "EXISTS" in sql:
+                ctid = str(tuple_params[0])
+                self.rowcount = 1 if ctid == "(0,1)" else 0
+                if self.rowcount == 1:
+                    self.deleted.append(ctid)
+                return
+            if sql.lstrip().startswith("UPDATE tool_events"):
+                ctid = str(tuple_params[1])
+                if ctid == "(0,3)":
+                    raise UniqueViolation("duplicate key value violates unique constraint")
+                self.rowcount = 1
+                self.updated.append(ctid)
+                return
+            if sql.lstrip().startswith("DELETE FROM tool_events"):
+                ctid = str(tuple_params[0])
+                self.rowcount = 1
+                self.deleted.append(ctid)
+                return
+            self.rowcount = 0
+
+    cursor = _Cursor()
+    ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    updated, deleted = _apply_backfill_updates(
+        cursor,
+        table="tool_events",
+        updates=[
+            ("(0,1)", ts, "existing"),
+            ("(0,2)", ts, "fresh"),
+            ("(0,3)", ts, "race"),
+        ],
+    )
+
+    assert updated == 1
+    assert deleted == 2
+    assert cursor.updated == ["(0,2)"]
+    assert cursor.deleted == ["(0,1)", "(0,3)"]

--- a/dashboard/tests/test_ingestor.py
+++ b/dashboard/tests/test_ingestor.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
+import threading
+import time
 from pathlib import Path
 
 from ego_dashboard.ingestor import EgoMcpLogProjector, normalize_event
@@ -423,3 +426,127 @@ def test_ingest_jsonl_line_only_stores_ego_mcp_server_logs() -> None:
 
     assert len(store.events) == 0
     assert len(store.logs) == 1
+
+
+class _CheckpointCaptureStore:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.logs: list[object] = []
+        self.checkpoints: dict[str, tuple[int, int]] = {}
+
+    def ingest(self, event: object) -> None:
+        self.events.append(event)
+
+    def ingest_log(self, event: object) -> None:
+        self.logs.append(event)
+
+    def load_checkpoint(self, path: str) -> tuple[int, int] | None:
+        return self.checkpoints.get(path)
+
+    def save_checkpoint(self, path: str, inode: int, offset: int) -> None:
+        self.checkpoints[path] = (inode, offset)
+
+
+def _append_json_line(path: Path, payload: dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload))
+        handle.write("\n")
+
+
+def _wait_until(predicate: object, timeout: float = 1.0) -> bool:
+    if not callable(predicate):
+        return False
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _run_tail_once(
+    path: str,
+    store: _CheckpointCaptureStore,
+    *,
+    wait_for: object | None = None,
+) -> None:
+    from ego_dashboard.ingestor import tail_jsonl_file
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=tail_jsonl_file,
+        args=(path, store),
+        kwargs={"poll_seconds": 0.01, "stop_event": stop_event},
+    )
+    thread.start()
+    try:
+        if wait_for is not None:
+            assert _wait_until(wait_for)
+        else:
+            time.sleep(0.05)
+    finally:
+        stop_event.set()
+        thread.join(timeout=1.0)
+        assert thread.is_alive() is False
+
+
+def test_tail_jsonl_file_resumes_from_saved_checkpoint(tmp_path: Path) -> None:
+    log_path = tmp_path / "ego-mcp-2026-01-01.log"
+    _append_json_line(
+        log_path,
+        {
+            "ts": "2026-01-01T12:00:00Z",
+            "event_type": "tool_call_completed",
+            "tool_name": "remember",
+        },
+    )
+    store = _CheckpointCaptureStore()
+
+    _run_tail_once(str(log_path), store, wait_for=lambda: len(store.events) == 1)
+    first_checkpoint = store.checkpoints[str(log_path)]
+
+    _run_tail_once(str(log_path), store)
+
+    assert len(store.events) == 1
+    assert store.checkpoints[str(log_path)] == first_checkpoint
+    assert first_checkpoint[1] == log_path.stat().st_size
+
+
+def test_tail_jsonl_file_tracks_checkpoints_per_globbed_file(tmp_path: Path) -> None:
+    first = tmp_path / "ego-mcp-2026-01-01.log"
+    second = tmp_path / "ego-mcp-2026-01-02.log"
+    _append_json_line(
+        first,
+        {
+            "ts": "2026-01-01T12:00:00Z",
+            "event_type": "tool_call_completed",
+            "tool_name": "remember",
+        },
+    )
+    _append_json_line(
+        second,
+        {
+            "ts": "2026-01-02T12:00:00Z",
+            "event_type": "tool_call_completed",
+            "tool_name": "wake_up",
+        },
+    )
+    store = _CheckpointCaptureStore()
+
+    _run_tail_once(str(tmp_path / "ego-mcp-*.log"), store, wait_for=lambda: len(store.events) == 2)
+    first_checkpoint = store.checkpoints[str(first)]
+    second_checkpoint = store.checkpoints[str(second)]
+
+    _append_json_line(
+        first,
+        {
+            "ts": "2026-01-01T12:05:00Z",
+            "event_type": "tool_call_completed",
+            "tool_name": "consider_them",
+        },
+    )
+    _run_tail_once(str(tmp_path / "ego-mcp-*.log"), store, wait_for=lambda: len(store.events) == 3)
+
+    assert len(store.events) == 3
+    assert store.checkpoints[str(first)][1] > first_checkpoint[1]
+    assert store.checkpoints[str(second)] == second_checkpoint

--- a/dashboard/tests/test_sql_store.py
+++ b/dashboard/tests/test_sql_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 import pytest
@@ -80,6 +80,110 @@ def _patch_store(
         lambda *_args, **_kwargs: _FakeConnection(rows),
     )
     return SqlTelemetryStore("postgresql://unused", "redis://unused")
+
+
+def test_tool_usage_prefers_log_invocations(monkeypatch: pytest.MonkeyPatch) -> None:
+    bucket_ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    executed: list[str] = []
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self._sql = ""
+
+        def execute(self, query: object, _params: object | None = None) -> None:
+            self._sql = str(query)
+            executed.append(self._sql)
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            if "FROM log_events" in self._sql:
+                return [(bucket_ts, "remember", 1)]
+            if "FROM tool_events" in self._sql:
+                return [(bucket_ts, "remember", 2)]
+            return []
+
+        def __enter__(self) -> _Cursor:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    class _Connection:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def __enter__(self) -> _Connection:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.Redis.from_url",
+        lambda *_args, **_kwargs: _FakeRedis(None),
+    )
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.psycopg.connect",
+        lambda *_args, **_kwargs: _Connection(),
+    )
+
+    store = SqlTelemetryStore("postgresql://unused", "redis://unused")
+    rows = store.tool_usage(bucket_ts, bucket_ts + timedelta(seconds=59), bucket="1m")
+
+    assert rows == [{"ts": bucket_ts.isoformat(), "remember": 1}]
+    assert sum("FROM tool_events" in sql for sql in executed) == 0
+
+
+def test_tool_usage_falls_back_to_terminal_events_when_logs_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bucket_ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    executed: list[str] = []
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self._sql = ""
+
+        def execute(self, query: object, _params: object | None = None) -> None:
+            self._sql = str(query)
+            executed.append(self._sql)
+
+        def fetchall(self) -> list[tuple[Any, ...]]:
+            if "FROM log_events" in self._sql:
+                return []
+            if "FROM tool_events" in self._sql:
+                return [(bucket_ts, "remember", 1)]
+            return []
+
+        def __enter__(self) -> _Cursor:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    class _Connection:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+        def __enter__(self) -> _Connection:
+            return self
+
+        def __exit__(self, *_args: object) -> Literal[False]:
+            return False
+
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.Redis.from_url",
+        lambda *_args, **_kwargs: _FakeRedis(None),
+    )
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.psycopg.connect",
+        lambda *_args, **_kwargs: _Connection(),
+    )
+
+    store = SqlTelemetryStore("postgresql://unused", "redis://unused")
+    rows = store.tool_usage(bucket_ts, bucket_ts + timedelta(seconds=59), bucket="1m")
+
+    assert rows == [{"ts": bucket_ts.isoformat(), "remember": 1}]
+    assert sum("FROM tool_events" in sql for sql in executed) == 1
 
 
 def test_current_includes_latest_emotion_and_backfills_latest(

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -47,6 +47,57 @@ def test_tool_usage_and_metric_history() -> None:
     assert intensity[1]["value"] == 0.7
 
 
+def test_tool_usage_prefers_invocation_logs_over_projected_events() -> None:
+    from ego_dashboard.models import LogEvent
+
+    store = TelemetryStore()
+    start = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=2)
+    store.ingest(
+        DashboardEvent(
+            ts=start,
+            event_type="tool_call_invoked",
+            tool_name="remember",
+            ok=True,
+            duration_ms=None,
+            numeric_metrics={},
+            string_metrics={},
+            params={},
+            private=False,
+            message="invoked",
+        )
+    )
+    store.ingest(
+        DashboardEvent(
+            ts=start + timedelta(seconds=1),
+            event_type="tool_call_completed",
+            tool_name="remember",
+            ok=True,
+            duration_ms=10,
+            numeric_metrics={},
+            string_metrics={},
+            params={},
+            private=False,
+            message="completed",
+        )
+    )
+    store.ingest_log(
+        LogEvent(
+            ts=start,
+            level="INFO",
+            logger="ego_mcp.server",
+            message="Tool invocation",
+            private=False,
+            fields={"tool_name": "remember"},
+        )
+    )
+
+    usage = store.tool_usage(start, end, bucket="1m")
+
+    assert usage[0]["remember"] == 1
+    assert usage[1]["remember"] == 0
+
+
 def test_string_visualization_and_anomaly_detection() -> None:
     store = TelemetryStore()
     for minute in range(5):
@@ -297,6 +348,44 @@ def test_current_prefers_log_derived_counts_and_error_rate() -> None:
             logger="ego_mcp.server",
             message="Tool execution failed",
             private=False,
+        )
+    )
+
+    current = store.current()
+
+    assert current["tool_calls_per_min"] == 1
+    assert current["error_rate"] == 1.0
+
+
+def test_current_falls_back_to_terminal_events_without_double_counting() -> None:
+    store = TelemetryStore()
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    store.ingest(
+        DashboardEvent(
+            ts=base,
+            event_type="tool_call_invoked",
+            tool_name="remember",
+            ok=True,
+            duration_ms=None,
+            numeric_metrics={},
+            string_metrics={},
+            params={},
+            private=False,
+            message="invoked",
+        )
+    )
+    store.ingest(
+        DashboardEvent(
+            ts=base + timedelta(seconds=2),
+            event_type="tool_call_failed",
+            tool_name="remember",
+            ok=False,
+            duration_ms=10,
+            numeric_metrics={},
+            string_metrics={},
+            params={},
+            private=False,
+            message="failed",
         )
     )
 


### PR DESCRIPTION
## Summary
- persist ingestor checkpoints per log file so restarts resume from the last offset instead of replaying old JSONL data
- add stable dedupe keys for telemetry/log ingestion and ignore exact duplicate inserts in the SQL store
- change tool usage aggregation to count `Tool invocation` logs as one call, with terminal-event fallback for older data
- add a cleanup script to backfill dedupe keys, remove replay duplicates, and optionally initialize checkpoints
- update backend docs and tests for restart resume, usage semantics, and dedupe cleanup

## Testing
- `cd dashboard && uv run pytest -v`
- `cd dashboard && uv run ruff check src tests`
- `cd dashboard && uv run ruff format --check src tests`
- `cd dashboard && uv run mypy src tests`
- `cd dashboard && docker compose config`