### PR TITLE
Fix private memory leaks in memory detail and expand dashboard memory graph support

### DIFF
--- a/dashboard/frontend/src/components/memory/memory-detail-panel.test.tsx
+++ b/dashboard/frontend/src/components/memory/memory-detail-panel.test.tsx
@@ -46,6 +46,37 @@ describe('MemoryDetailPanel', () => {
     expect(screen.getByText('mem-2')).toBeInTheDocument()
     expect(screen.getByText('notion-1')).toBeInTheDocument()
   })
+
+  it('redacts private memory content', () => {
+    render(
+      <MemoryDetailPanel
+        detail={{
+          id: 'mem-private',
+          content: 'This should never appear in the detail panel.',
+          timestamp: '2026-01-01T12:00:00Z',
+          category: 'technical',
+          importance: 4,
+          tags: ['private'],
+          is_private: true,
+          access_count: 2,
+          last_accessed: '2026-01-02T12:00:00Z',
+          decay: 0.61,
+          emotional_trace: {
+            valence: 0.2,
+            arousal: 0.4,
+            intensity: 0.5,
+          },
+          linked_ids: [],
+          generated_notion_ids: [],
+        }}
+      />,
+    )
+
+    expect(screen.getByText('REDACTED')).toBeInTheDocument()
+    expect(
+      screen.queryByText('This should never appear in the detail panel.'),
+    ).not.toBeInTheDocument()
+  })
 })
 
 describe('NotionDetailPanel', () => {

--- a/dashboard/frontend/src/components/memory/memory-detail-panel.tsx
+++ b/dashboard/frontend/src/components/memory/memory-detail-panel.tsx
@@ -6,6 +6,8 @@ type MemoryDetailPanelProps = {
   detail: MemoryDetail
 }
 
+const PRIVATE_CONTENT_PLACEHOLDER = 'REDACTED'
+
 const formatTimestamp = (value: string) =>
   value ? new Date(value).toLocaleString() : 'n/a'
 
@@ -84,7 +86,7 @@ export const MemoryDetailPanel = ({ detail }: MemoryDetailPanelProps) => (
           Content
         </p>
         <div className="max-h-56 overflow-y-auto rounded-md border bg-muted/20 p-3 whitespace-pre-wrap">
-          {detail.content}
+          {detail.is_private ? PRIVATE_CONTENT_PLACEHOLDER : detail.content}
         </div>
       </div>
 

--- a/dashboard/src/ego_dashboard/api.py
+++ b/dashboard/src/ego_dashboard/api.py
@@ -614,14 +614,15 @@ def _load_memory_detail(settings: DashboardSettings, memory_id: str) -> dict[str
             continue
         if memory_id in source_memory_ids:
             generated_notion_ids.append(str(notion["id"]))
+    is_private = bool(memory.get("is_private", False))
     return {
         "id": memory_id,
-        "content": str(memory.get("content", "")),
+        "content": "REDACTED" if is_private else str(memory.get("content", "")),
         "timestamp": str(memory.get("timestamp", "")),
         "category": str(memory.get("category", "")),
         "importance": _coerce_int(memory.get("importance"), 3),
         "tags": memory.get("tags", []),
-        "is_private": bool(memory.get("is_private", False)),
+        "is_private": is_private,
         "access_count": _coerce_int(memory.get("access_count"), 0),
         "last_accessed": str(memory.get("last_accessed", "")),
         "decay": _coerce_float(memory.get("decay"), 0.0),

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -802,6 +802,64 @@ def test_memory_detail_endpoint_returns_full_memory_and_generated_notions(
     }
 
 
+def test_memory_detail_endpoint_redacts_private_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_memory_collection(
+        monkeypatch,
+        tmp_path,
+        [
+            (
+                "mem_private",
+                "Top secret memory body that must not be exposed in detail view.",
+                {
+                    "category": "technical",
+                    "timestamp": "2026-01-01T12:00:00+00:00",
+                    "access_count": 2,
+                    "importance": 4,
+                    "tags": "secret",
+                    "is_private": True,
+                    "linked_ids": "[]",
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "ego_dashboard.api._calculate_memory_decay",
+        lambda timestamp, *, link_confidence_max, access_count, now=None: 0.61,
+    )
+
+    app = create_app(
+        TelemetryStore(),
+        settings=DashboardSettings(ego_mcp_data_dir=str(tmp_path)),
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/memory/mem_private")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "mem_private",
+        "content": "REDACTED",
+        "timestamp": "2026-01-01T12:00:00+00:00",
+        "category": "technical",
+        "importance": 4,
+        "tags": ["secret"],
+        "is_private": True,
+        "access_count": 2,
+        "last_accessed": "",
+        "decay": 0.61,
+        "emotional_trace": {
+            "valence": 0.0,
+            "arousal": 0.5,
+            "intensity": 0.5,
+        },
+        "linked_ids": [],
+        "generated_notion_ids": [],
+    }
+
+
 def test_memory_detail_endpoint_returns_404_when_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- redact private memory content in the memory detail API and UI so `is_private` entries do not expose their body
- add regression coverage for private memory detail handling in backend and frontend tests
- include the broader dashboard memory graph work shipped on this branch, including new graph UI, filters, stats, history integration, and related API/types updates
- update dashboard config, dependency lockfiles, and documentation to support the new memory graph surface

## Testing
- `cd dashboard && uv sync --group dev`
- `cd dashboard && uv run pytest -v`
- `cd dashboard && uv run ruff check src tests`
- `cd dashboard && uv run ruff format --check src tests`
- `cd dashboard && uv run mypy src tests`
- `cd dashboard && docker compose config`
- `cd dashboard/frontend && npm ci`
- `cd dashboard/frontend && npm run lint`
- `cd dashboard/frontend && npm run format:check`
- `cd dashboard/frontend && npm run test`
- `cd dashboard/frontend && npm run build`