### PR TITLE
Fix type validation for update_relationship/update_self

### DIFF
--- a/ego-mcp/src/ego_mcp/_server_backend_handlers.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_handlers.py
@@ -328,14 +328,22 @@ def _handle_update_relationship(config: EgoConfig, args: dict[str, Any]) -> str:
     relationship_store = _relationship_store(config)
     try:
         relationship_store.update(person, {field_name: value})
-    except ValueError as exc:
+    except (ValueError, TypeError) as exc:
         return f"Error: {exc}"
     return f"Updated {person}.{field_name}"
 
 
+_SELF_FIELD_ALIASES: dict[str, str] = {
+    "confidence": "confidence_calibration",
+    "goals": "current_goals",
+    "values": "discovered_values",
+    "narratives": "identity_narratives",
+}
+
+
 def _handle_update_self(config: EgoConfig, args: dict[str, Any]) -> str:
     """Update self model."""
-    field_name = args["field"]
+    field_name = _SELF_FIELD_ALIASES.get(args["field"], args["field"])
     value = args["value"]
     store = SelfModelStore(config.data_dir / "self_model.json")
 
@@ -356,7 +364,10 @@ def _handle_update_self(config: EgoConfig, args: dict[str, Any]) -> str:
             return f"Updated question importance for {question_id}."
         return f"Question {question_id} not found."
 
-    store.update({field_name: value})
+    try:
+        store.update({field_name: value})
+    except (ValueError, TypeError) as exc:
+        return f"Error: {exc}"
     return f"Updated self.{field_name}"
 
 

--- a/ego-mcp/src/ego_mcp/relationship.py
+++ b/ego-mcp/src/ego_mcp/relationship.py
@@ -17,6 +17,23 @@ _UPDATABLE_FIELDS = frozenset(
     if field.name not in ("person_id",)
 )
 
+# Expected types for each updatable field.
+_FIELD_TYPES: dict[str, type | tuple[type, ...]] = {
+    "name": str,
+    "known_facts": list,
+    "communication_style": dict,
+    "preferred_topics": list,
+    "sensitive_topics": list,
+    "emotional_baseline": dict,
+    "trust_level": (int, float),
+    "shared_episode_ids": list,
+    "inferred_personality": dict,
+    "recent_mood_trajectory": list,
+    "first_interaction": str,
+    "last_interaction": str,
+    "total_interactions": (int, float),
+}
+
 
 class RelationshipStore:
     """JSON-backed store for per-person relationship models."""
@@ -81,6 +98,13 @@ class RelationshipStore:
                 f"Invalid relationship field(s): {invalid}. "
                 f"Valid fields: {valid_fields}"
             )
+        for key, value in patch.items():
+            expected = _FIELD_TYPES.get(key)
+            if expected is not None and not isinstance(value, expected):
+                raise TypeError(
+                    f"Field '{key}' expects {expected.__name__ if isinstance(expected, type) else ' or '.join(t.__name__ for t in expected)}, "
+                    f"got {type(value).__name__}: {value!r}"
+                )
         raw = self._get_raw(person_id)
         for key, value in patch.items():
             raw[key] = value

--- a/ego-mcp/src/ego_mcp/self_model.py
+++ b/ego-mcp/src/ego_mcp/self_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import math
 import uuid
@@ -12,6 +13,21 @@ from typing import Any
 
 from ego_mcp import timezone_utils
 from ego_mcp.types import SelfModel
+
+_UPDATABLE_FIELDS = frozenset(
+    f.name for f in dataclasses.fields(SelfModel) if f.name not in ("last_updated",)
+)
+
+_FIELD_TYPES: dict[str, type | tuple[type, ...]] = {
+    "preferences": dict,
+    "discovered_values": dict,
+    "skill_confidence": dict,
+    "current_goals": list,
+    "unresolved_questions": list,
+    "identity_narratives": list,
+    "growth_log": list,
+    "confidence_calibration": (int, float),
+}
 
 
 def _clamp_question_importance(value: Any) -> int:
@@ -118,6 +134,21 @@ class SelfModelStore:
         )
 
     def update(self, patch: dict[str, Any]) -> SelfModel:
+        invalid_fields = sorted(key for key in patch if key not in _UPDATABLE_FIELDS)
+        if invalid_fields:
+            valid_fields = ", ".join(sorted(_UPDATABLE_FIELDS))
+            invalid = ", ".join(invalid_fields)
+            raise ValueError(
+                f"Invalid self-model field(s): {invalid}. "
+                f"Valid fields: {valid_fields}"
+            )
+        for key, value in patch.items():
+            expected = _FIELD_TYPES.get(key)
+            if expected is not None and not isinstance(value, expected):
+                raise TypeError(
+                    f"Field '{key}' expects {expected.__name__ if isinstance(expected, type) else ' or '.join(t.__name__ for t in expected)}, "
+                    f"got {type(value).__name__}: {value!r}"
+                )
         for key, value in patch.items():
             self._data[key] = value
         self._data["last_updated"] = timezone_utils.now().isoformat()

--- a/ego-mcp/tests/test_integration.py
+++ b/ego-mcp/tests/test_integration.py
@@ -2279,6 +2279,79 @@ class TestUpdateRelationship:
         rel = store.get("Master")
         assert rel.emotional_baseline == {"warm": 1.0}
 
+    @pytest.mark.asyncio
+    async def test_rejects_string_for_communication_style(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_relationship",
+            {
+                "person": "Master",
+                "field": "communication_style",
+                "value": "calm and warm",
+            },
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "communication_style" in result
+        assert "dict" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_string_for_list_field(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_relationship",
+            {
+                "person": "Master",
+                "field": "known_facts",
+                "value": "likes coffee",
+            },
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "known_facts" in result
+        assert "list" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_string_for_trust_level(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_relationship",
+            {"person": "Master", "field": "trust_level", "value": "high"},
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "trust_level" in result
+
 
 class TestUpdateSelf:
     @pytest.mark.asyncio
@@ -2299,7 +2372,7 @@ class TestUpdateSelf:
             episodes,
             consolidation,
         )
-        assert "Updated self.confidence" in result
+        assert "Updated self.confidence_calibration" in result
 
     @pytest.mark.asyncio
     async def test_resolve_question_via_update_self(
@@ -2346,6 +2419,71 @@ class TestUpdateSelf:
             consolidation,
         )
         assert f"Updated question importance for {qid}" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_field(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_self",
+            {"field": "nonexistent_field", "value": "anything"},
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "Invalid self-model field" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_string_for_dict_field(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_self",
+            {"field": "preferences", "value": "likes quiet work"},
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "preferences" in result
+        assert "dict" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_string_for_list_field(
+        self,
+        config: EgoConfig,
+        memory: MemoryStore,
+        desire: DesireEngine,
+        episodes: EpisodeStore,
+        consolidation: ConsolidationEngine,
+    ) -> None:
+        result = await _call(
+            "update_self",
+            {"field": "current_goals", "value": "ship the patch"},
+            config,
+            memory,
+            desire,
+            episodes,
+            consolidation,
+        )
+        assert result.startswith("Error:")
+        assert "current_goals" in result
+        assert "list" in result
 
 
 class TestGetEpisode:

--- a/ego-mcp/tests/test_relationship.py
+++ b/ego-mcp/tests/test_relationship.py
@@ -71,6 +71,35 @@ class TestRelationshipStore:
         rel = store.get("Master")
         assert rel.total_interactions == 0
 
+    def test_update_rejects_wrong_type_for_dict_field(self, tmp_path: Path) -> None:
+        store = RelationshipStore(tmp_path / "relationships.json")
+        with pytest.raises(TypeError, match="communication_style.*dict.*str"):
+            store.update("Master", {"communication_style": "calm and warm"})
+
+    def test_update_rejects_wrong_type_for_list_field(self, tmp_path: Path) -> None:
+        store = RelationshipStore(tmp_path / "relationships.json")
+        with pytest.raises(TypeError, match="known_facts.*list.*str"):
+            store.update("Master", {"known_facts": "likes coffee"})
+
+    def test_update_rejects_wrong_type_for_numeric_field(self, tmp_path: Path) -> None:
+        store = RelationshipStore(tmp_path / "relationships.json")
+        with pytest.raises(TypeError, match="trust_level"):
+            store.update("Master", {"trust_level": "high"})
+
+    def test_update_accepts_correct_types(self, tmp_path: Path) -> None:
+        store = RelationshipStore(tmp_path / "relationships.json")
+        updated = store.update(
+            "Master",
+            {
+                "communication_style": {"warm": 3.0},
+                "known_facts": ["likes coffee"],
+                "trust_level": 0.9,
+            },
+        )
+        assert updated.communication_style == {"warm": 3.0}
+        assert updated.known_facts == ["likes coffee"]
+        assert updated.trust_level == 0.9
+
     def test_apply_tom_feedback(self, tmp_path: Path) -> None:
         store = RelationshipStore(tmp_path / "relationships.json")
         updated = store.apply_tom_feedback(

--- a/ego-mcp/tests/test_self_model.py
+++ b/ego-mcp/tests/test_self_model.py
@@ -28,6 +28,26 @@ class TestSelfModelStore:
         assert model.current_goals == ["learn"]
         assert model.last_updated != ""
 
+    def test_update_rejects_unknown_field(self, tmp_path: Path) -> None:
+        store = SelfModelStore(tmp_path / "self_model.json")
+        with pytest.raises(ValueError, match="Invalid self-model field"):
+            store.update({"nonexistent": "value"})
+
+    def test_update_rejects_wrong_type_for_dict_field(self, tmp_path: Path) -> None:
+        store = SelfModelStore(tmp_path / "self_model.json")
+        with pytest.raises(TypeError, match="preferences.*dict.*str"):
+            store.update({"preferences": "likes quiet"})
+
+    def test_update_rejects_wrong_type_for_list_field(self, tmp_path: Path) -> None:
+        store = SelfModelStore(tmp_path / "self_model.json")
+        with pytest.raises(TypeError, match="current_goals.*list.*str"):
+            store.update({"current_goals": "ship the patch"})
+
+    def test_update_rejects_wrong_type_for_numeric_field(self, tmp_path: Path) -> None:
+        store = SelfModelStore(tmp_path / "self_model.json")
+        with pytest.raises(TypeError, match="confidence_calibration"):
+            store.update({"confidence_calibration": "high"})
+
     def test_add_question_and_resolve(self, tmp_path: Path) -> None:
         store = SelfModelStore(tmp_path / "self_model.json")
         qid = store.add_question("What should I prioritize?")


### PR DESCRIPTION
## Summary
- `RelationshipStore.update()` と `SelfModelStore.update()` にフィールド値の型バリデーションを追加。LLMが `dict[str, float]` や `list[str]` であるべきフィールドに文字列を渡すと、JSONストアが破損し起動に失敗する問題を修正
- `SelfModelStore.update()` にフィールド名バリデーションを追加（以前は任意のキーを書き込み可能だった）
- `_handle_update_self` にセルフモデル用フィールドエイリアスを追加（`confidence` → `confidence_calibration` 等）
- バリデーションエラー時はスタックトレースではなく、何が間違っているか分かるエラーメッセージを返す

## Test plan
- [x] `test_relationship.py`: 型バリデーション4テスト追加
- [x] `test_self_model.py`: フィールド名・型バリデーション4テスト追加
- [x] `test_integration.py`: E2Eバリデーション6テスト追加
- [x] 全434テスト通過、isort/ruff/mypy OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)