### PR TITLE
[codex] Fix PR26 review findings

### DIFF
--- a/dashboard/src/ego_dashboard/constants.py
+++ b/dashboard/src/ego_dashboard/constants.py
@@ -19,3 +19,9 @@ DESIRE_TELEMETRY_TOOL_NAMES: tuple[str, ...] = (
     "feel_desires",
     "attune",
 )
+
+# Only terminal events carry computed desire metrics.
+DESIRE_TERMINAL_EVENT_TYPES: tuple[str, ...] = (
+    "tool_call_completed",
+    "tool_call_failed",
+)

--- a/dashboard/src/ego_dashboard/constants.py
+++ b/dashboard/src/ego_dashboard/constants.py
@@ -12,3 +12,10 @@ DESIRE_METRIC_KEYS: tuple[str, ...] = (
     "expression",
     "curiosity",
 )
+
+# ego-mcp used `feel_desires` historically, then moved desire telemetry into `attune`.
+# Dashboard readers need to understand both so historical and v1.0.0 data render together.
+DESIRE_TELEMETRY_TOOL_NAMES: tuple[str, ...] = (
+    "feel_desires",
+    "attune",
+)

--- a/dashboard/src/ego_dashboard/ingestor.py
+++ b/dashboard/src/ego_dashboard/ingestor.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
+from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES
 from ego_dashboard.desire_catalog import DesireCatalog, default_desire_catalog, load_desire_catalog
 from ego_dashboard.models import DashboardEvent, LogEvent
 from ego_dashboard.settings import load_settings
@@ -139,9 +140,9 @@ class EgoMcpLogProjector:
             return None
 
         if message == "Tool invocation":
-            if tool_name == "feel_desires":
-                # For feel_desires we project completion/failure instead so we can attach
-                # the computed desire levels without double-counting tool usage.
+            if tool_name in DESIRE_TELEMETRY_TOOL_NAMES:
+                # For desire tools we project completion/failure instead so we
+                # can attach computed desire levels without double-counting.
                 return None
             tool_args = raw.get("tool_args")
             safe_tool_args = tool_args if isinstance(tool_args, dict) else {}
@@ -162,7 +163,7 @@ class EgoMcpLogProjector:
                 True,
                 "tool_call_completed",
             )
-            if tool_name == "feel_desires":
+            if tool_name in DESIRE_TELEMETRY_TOOL_NAMES:
                 parsed_levels = self._parse_feel_desires_levels(raw)
                 if parsed_levels:
                     raw_params = event_raw.get("params")
@@ -181,7 +182,7 @@ class EgoMcpLogProjector:
                 False,
                 "tool_call_failed",
             )
-            if tool_name == "feel_desires":
+            if tool_name in DESIRE_TELEMETRY_TOOL_NAMES:
                 parsed_levels = self._parse_feel_desires_levels(raw)
                 if parsed_levels:
                     raw_params = event_raw.get("params")

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -8,12 +8,14 @@ from datetime import UTC, datetime, timedelta
 import psycopg
 from redis import Redis
 
+from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES
 from ego_dashboard.desire_catalog import DesireCatalog, default_desire_catalog
 from ego_dashboard.models import DashboardEvent, LogEvent
 from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
 
 logger = logging.getLogger(__name__)
 _TOOL_OUTPUT_CHARS_CLEANUP_MIGRATION = "20260401_remove_tool_output_chars_metric"
+_DESIRE_TERMINAL_EVENT_TYPES = ("tool_call_completed", "tool_call_failed")
 
 
 def _escape_ilike_pattern(value: str) -> str:
@@ -59,6 +61,10 @@ def _tool_name_from_fields(fields: object) -> str | None:
         return None
     raw = fields.get("tool_name")
     return raw if isinstance(raw, str) and raw else None
+
+
+def _desire_tool_names_param() -> list[str]:
+    return list(DESIRE_TELEMETRY_TOOL_NAMES)
 
 
 def _dense_usage_rows(
@@ -210,12 +216,13 @@ class SqlTelemetryStore:
             UPDATE tool_events
             SET numeric_metrics = numeric_metrics - 'tool_output_chars',
                 params = params - 'tool_output_chars'
-            WHERE tool_name = 'feel_desires'
+            WHERE tool_name = ANY(%s)
               AND (
                 numeric_metrics ? 'tool_output_chars'
                 OR params ? 'tool_output_chars'
               )
             """,
+            (_desire_tool_names_param(),),
         )
 
     def _apply_tool_events_cleanup_migration(
@@ -223,12 +230,16 @@ class SqlTelemetryStore:
         cur: psycopg.Cursor[object],
         migration_name: str,
         sql: str,
+        params: tuple[object, ...] | None = None,
     ) -> None:
         cur.execute("SELECT 1 FROM dashboard_migrations WHERE name = %s", (migration_name,))
         if cur.fetchone() is not None:
             return
 
-        cur.execute(sql)
+        if params is None:
+            cur.execute(sql)
+        else:
+            cur.execute(sql, params)
         rowcount = getattr(cur, "rowcount", 0)
         cleaned_rows = int(rowcount) if isinstance(rowcount, int) else 0
         cur.execute(
@@ -421,10 +432,12 @@ class SqlTelemetryStore:
                     """
                     SELECT numeric_metrics
                     FROM tool_events
-                    WHERE ts >= %s AND ts <= %s AND tool_name = 'feel_desires'
+                    WHERE ts >= %s AND ts <= %s
+                      AND tool_name = ANY(%s)
+                      AND event_type = ANY(%s)
                     ORDER BY ts ASC
                     """,
-                    (start, end),
+                    (start, end, _desire_tool_names_param(), list(_DESIRE_TERMINAL_EVENT_TYPES)),
                 )
                 rows = cur.fetchall()
 
@@ -765,11 +778,17 @@ class SqlTelemetryStore:
                     """
                     SELECT numeric_metrics
                     FROM tool_events
-                    WHERE ts <= %s AND tool_name = 'feel_desires'
+                    WHERE ts <= %s
+                      AND tool_name = ANY(%s)
+                      AND event_type = ANY(%s)
                     ORDER BY ts DESC
                     LIMIT 1
                     """,
-                    (latest_ts,),
+                    (
+                        latest_ts,
+                        _desire_tool_names_param(),
+                        list(_DESIRE_TERMINAL_EVENT_TYPES),
+                    ),
                 )
                 latest_desire_row = cur.fetchone()
                 latest_desires: dict[str, float] = {}

--- a/dashboard/src/ego_dashboard/sql_store.py
+++ b/dashboard/src/ego_dashboard/sql_store.py
@@ -8,14 +8,13 @@ from datetime import UTC, datetime, timedelta
 import psycopg
 from redis import Redis
 
-from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES
+from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES, DESIRE_TERMINAL_EVENT_TYPES
 from ego_dashboard.desire_catalog import DesireCatalog, default_desire_catalog
 from ego_dashboard.models import DashboardEvent, LogEvent
 from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
 
 logger = logging.getLogger(__name__)
 _TOOL_OUTPUT_CHARS_CLEANUP_MIGRATION = "20260401_remove_tool_output_chars_metric"
-_DESIRE_TERMINAL_EVENT_TYPES = ("tool_call_completed", "tool_call_failed")
 
 
 def _escape_ilike_pattern(value: str) -> str:
@@ -437,7 +436,7 @@ class SqlTelemetryStore:
                       AND event_type = ANY(%s)
                     ORDER BY ts ASC
                     """,
-                    (start, end, _desire_tool_names_param(), list(_DESIRE_TERMINAL_EVENT_TYPES)),
+                    (start, end, _desire_tool_names_param(), list(DESIRE_TERMINAL_EVENT_TYPES)),
                 )
                 rows = cur.fetchall()
 
@@ -787,7 +786,7 @@ class SqlTelemetryStore:
                     (
                         latest_ts,
                         _desire_tool_names_param(),
-                        list(_DESIRE_TERMINAL_EVENT_TYPES),
+                        list(DESIRE_TERMINAL_EVENT_TYPES),
                     ),
                 )
                 latest_desire_row = cur.fetchone()

--- a/dashboard/src/ego_dashboard/store.py
+++ b/dashboard/src/ego_dashboard/store.py
@@ -5,7 +5,7 @@ from collections import Counter
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 
-from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES
+from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES, DESIRE_TERMINAL_EVENT_TYPES
 from ego_dashboard.desire_catalog import DesireCatalog, default_desire_catalog
 from ego_dashboard.models import DashboardEvent, LogEvent
 from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
@@ -83,6 +83,8 @@ class TelemetryStore:
 
     def _desire_metrics_for_event(self, event: DashboardEvent) -> dict[str, float]:
         if event.tool_name not in DESIRE_TELEMETRY_TOOL_NAMES:
+            return {}
+        if event.event_type not in DESIRE_TERMINAL_EVENT_TYPES:
             return {}
         desire_metrics: dict[str, float] = {}
         for key, value in event.numeric_metrics.items():

--- a/dashboard/src/ego_dashboard/store.py
+++ b/dashboard/src/ego_dashboard/store.py
@@ -5,6 +5,7 @@ from collections import Counter
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 
+from ego_dashboard.constants import DESIRE_TELEMETRY_TOOL_NAMES
 from ego_dashboard.desire_catalog import DesireCatalog, default_desire_catalog
 from ego_dashboard.models import DashboardEvent, LogEvent
 from ego_dashboard.telemetry_identity import dashboard_event_dedupe_key, log_event_dedupe_key
@@ -80,18 +81,21 @@ class TelemetryStore:
                 break
         return latest
 
-    def _latest_desire_metrics(self) -> dict[str, float]:
-        source = next(
-            (event for event in reversed(self._events) if event.tool_name == "feel_desires"),
-            None,
-        )
-        if source is None:
+    def _desire_metrics_for_event(self, event: DashboardEvent) -> dict[str, float]:
+        if event.tool_name not in DESIRE_TELEMETRY_TOOL_NAMES:
             return {}
         desire_metrics: dict[str, float] = {}
-        for key, value in source.numeric_metrics.items():
+        for key, value in event.numeric_metrics.items():
             if self._desire_catalog.is_visible_desire_metric(key):
                 desire_metrics[key] = float(value)
         return desire_metrics
+
+    def _latest_desire_metrics(self) -> dict[str, float]:
+        for event in reversed(self._events):
+            desire_metrics = self._desire_metrics_for_event(event)
+            if desire_metrics:
+                return desire_metrics
+        return {}
 
     def _bucket_events(
         self, events: list[DashboardEvent], start: datetime, end: datetime, bucket: str
@@ -257,11 +261,7 @@ class TelemetryStore:
     def desire_metric_keys(self, start: datetime, end: datetime) -> list[str]:
         keys: set[str] = set()
         for event in self._filtered(start, end):
-            if event.tool_name != "feel_desires":
-                continue
-            for key in event.numeric_metrics:
-                if self._desire_catalog.is_visible_desire_metric(key):
-                    keys.add(key)
+            keys.update(self._desire_metrics_for_event(event))
         return sorted(keys)
 
     def current(self) -> dict[str, object]:

--- a/dashboard/tests/test_ingestor.py
+++ b/dashboard/tests/test_ingestor.py
@@ -262,6 +262,39 @@ def test_projector_parses_feel_desires_completion_metrics() -> None:
     assert event.numeric_metrics["curiosity"] == 0.7
 
 
+def test_projector_carries_attune_desire_metrics_from_completion_log() -> None:
+    projector = EgoMcpLogProjector()
+    completion = {
+        "timestamp": "2026-01-01T12:00:02Z",
+        "level": "INFO",
+        "logger": "ego_mcp.server",
+        "message": "Tool execution completed",
+        "tool_name": "attune",
+        "emotion_primary": "curious",
+        "emotion_intensity": 0.65,
+        "valence": 0.2,
+        "arousal": 0.7,
+        "time_phase": "night",
+        "desire_levels": {
+            "information_hunger": 0.8,
+            "curiosity": 0.7,
+        },
+        "information_hunger": 0.8,
+        "curiosity": 0.7,
+        "You want to feel safe.": 0.4,
+    }
+
+    event = projector.project(completion)
+
+    assert event is not None
+    assert event.tool_name == "attune"
+    assert event.ok is True
+    assert event.string_metrics["time_phase"] == "night"
+    assert event.numeric_metrics["information_hunger"] == 0.8
+    assert event.numeric_metrics["curiosity"] == 0.7
+    assert event.numeric_metrics["You want to feel safe."] == 0.4
+
+
 def test_projector_preserves_forgetting_and_notion_metrics() -> None:
     projector = EgoMcpLogProjector()
     completion = {

--- a/dashboard/tests/test_ingestor.py
+++ b/dashboard/tests/test_ingestor.py
@@ -295,6 +295,41 @@ def test_projector_carries_attune_desire_metrics_from_completion_log() -> None:
     assert event.numeric_metrics["You want to feel safe."] == 0.4
 
 
+def test_projector_skips_attune_invocation_event() -> None:
+    """Attune invocation events should be skipped like feel_desires (Finding 7)."""
+    projector = EgoMcpLogProjector()
+    invocation = {
+        "timestamp": "2026-01-01T12:00:00Z",
+        "level": "INFO",
+        "logger": "ego_mcp.server",
+        "message": "Tool invocation",
+        "tool_name": "attune",
+        "tool_args": {},
+    }
+    event = projector.project(invocation)
+    assert event is None
+
+
+def test_projector_parses_attune_desire_levels_from_structured_dict() -> None:
+    """Attune should use _parse_feel_desires_levels for structured desire_levels (Finding 8)."""
+    projector = EgoMcpLogProjector()
+    completion = {
+        "timestamp": "2026-01-01T12:00:02Z",
+        "level": "INFO",
+        "logger": "ego_mcp.server",
+        "message": "Tool execution completed",
+        "tool_name": "attune",
+        "desire_levels": {
+            "information_hunger": 0.8,
+            "curiosity": 0.7,
+        },
+    }
+    event = projector.project(completion)
+    assert event is not None
+    assert event.numeric_metrics["information_hunger"] == 0.8
+    assert event.numeric_metrics["curiosity"] == 0.7
+
+
 def test_projector_preserves_forgetting_and_notion_metrics() -> None:
     projector = EgoMcpLogProjector()
     completion = {

--- a/dashboard/tests/test_sql_store.py
+++ b/dashboard/tests/test_sql_store.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, cast
 
 import pytest
 
-from ego_dashboard.constants import DESIRE_METRIC_KEYS
+from ego_dashboard.constants import DESIRE_METRIC_KEYS, DESIRE_TELEMETRY_TOOL_NAMES
 from ego_dashboard.desire_catalog import DesireCatalog, DesireCatalogItem
 from ego_dashboard.sql_store import SqlTelemetryStore
 
@@ -256,6 +256,11 @@ def test_sql_store_initialize_ingest_and_checkpoint_methods(
     assert any("CREATE TABLE IF NOT EXISTS dashboard_migrations" in sql for sql, _ in statements)
     assert any(
         "numeric_metrics = numeric_metrics - 'tool_output_chars'" in sql for sql, _ in statements
+    )
+    assert any(
+        "numeric_metrics = numeric_metrics - 'tool_output_chars'" in sql
+        and params == (list(DESIRE_TELEMETRY_TOOL_NAMES),)
+        for sql, params in statements
     )
     assert any("INSERT INTO dashboard_migrations" in sql for sql, _ in statements)
     assert any(
@@ -700,6 +705,68 @@ def test_desire_metric_keys_reads_dynamic_keys_from_feel_desires_events(
     assert keys == ["You want to feel safe.", "curiosity"]
 
 
+def test_desire_metric_keys_reads_dynamic_keys_from_attune_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[tuple[str, tuple[Any, ...] | None]] = []
+
+    class _CapturingCursor(_FakeCursor):
+        def __init__(self) -> None:
+            super().__init__(
+                rows=[],
+                all_rows=[
+                    (
+                        {
+                            "curiosity": 0.7,
+                            "You want to feel safe.": 0.4,
+                            "impulse_boost_amount": 0.2,
+                        },
+                    )
+                ],
+            )
+
+        def execute(self, *args: object, **kwargs: object) -> None:
+            query = args[0] if args else kwargs.get("query")
+            params = args[1] if len(args) > 1 else kwargs.get("params")
+            sql = str(query)
+            tuple_params = params if isinstance(params, tuple) else None
+            executed.append((sql, tuple_params))
+
+    class _CapturingConnection(_FakeConnection):
+        def __init__(self) -> None:
+            self._cursor = _CapturingCursor()
+
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.Redis.from_url",
+        lambda *_args, **_kwargs: _FakeRedis(None),
+    )
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.psycopg.connect",
+        lambda *_args, **_kwargs: _CapturingConnection(),
+    )
+    store = SqlTelemetryStore("postgresql://unused", "redis://unused")
+
+    keys = store.desire_metric_keys(
+        datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+        datetime(2026, 1, 1, 12, 10, tzinfo=UTC),
+    )
+
+    assert keys == ["You want to feel safe.", "curiosity"]
+    desire_queries = [
+        params
+        for sql, params in executed
+        if "tool_name = ANY(%s)" in sql and "event_type = ANY(%s)" in sql
+    ]
+    assert desire_queries == [
+        (
+            datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+            datetime(2026, 1, 1, 12, 10, tzinfo=UTC),
+            list(DESIRE_TELEMETRY_TOOL_NAMES),
+            ["tool_call_completed", "tool_call_failed"],
+        )
+    ]
+
+
 def test_current_and_desire_keys_follow_catalog_and_hide_removed_legacy_fixed_desires(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -768,6 +835,76 @@ def test_current_and_desire_keys_follow_catalog_and_hide_removed_legacy_fixed_de
     )
     keys = store.desire_metric_keys(latest_ts - timedelta(minutes=5), latest_ts)
     assert keys == ["You want to feel safe.", "custom_focus", "social_thirst"]
+
+
+def test_current_uses_latest_attune_desire_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    latest_ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    executed: list[tuple[str, tuple[Any, ...] | None]] = []
+
+    class _CapturingCursor(_FakeCursor):
+        def execute(self, *args: object, **kwargs: object) -> None:
+            query = args[0] if args else kwargs.get("query")
+            params = args[1] if len(args) > 1 else kwargs.get("params")
+            sql = str(query)
+            tuple_params = params if isinstance(params, tuple) else None
+            executed.append((sql, tuple_params))
+
+    class _CapturingConnection(_FakeConnection):
+        def __init__(self) -> None:
+            self._cursor = _CapturingCursor(
+                [
+                    (1, 0),
+                    (5, 0),
+                    (0, 0),
+                    (0, 0),
+                    None,
+                    None,
+                    (
+                        {
+                            "curiosity": 0.8,
+                            "You want to feel safe.": 0.55,
+                            "impulse_boost_amount": 0.15,
+                        },
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.Redis.from_url",
+        lambda *_args, **_kwargs: _FakeRedis(
+            json.dumps(
+                {
+                    "ts": latest_ts.isoformat(),
+                    "tool_name": "attune",
+                    "private": False,
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "ego_dashboard.sql_store.psycopg.connect",
+        lambda *_args, **_kwargs: _CapturingConnection(),
+    )
+
+    store = SqlTelemetryStore("postgresql://unused", "redis://unused")
+    current = store.current()
+
+    assert current["latest_desires"] == {"curiosity": 0.8}
+    assert current["latest_emergent_desires"] == {"You want to feel safe.": 0.55}
+    desire_queries = [
+        params
+        for sql, params in executed
+        if "SELECT numeric_metrics" in sql and "tool_name = ANY(%s)" in sql
+    ]
+    assert desire_queries == [
+        (
+            latest_ts,
+            list(DESIRE_TELEMETRY_TOOL_NAMES),
+            ["tool_call_completed", "tool_call_failed"],
+        )
+    ]
 
 
 def test_notion_history_prefers_per_notion_confidence_mapping(

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -251,6 +251,40 @@ def test_desire_metric_keys_include_dynamic_history_only_keys() -> None:
     ]
 
 
+def test_current_and_desire_metric_keys_accept_attune_events() -> None:
+    store = TelemetryStore()
+    start = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    store.ingest(
+        DashboardEvent(
+            ts=start,
+            event_type="tool_call_completed",
+            tool_name="attune",
+            ok=True,
+            duration_ms=10,
+            emotion_primary="curious",
+            emotion_intensity=0.6,
+            numeric_metrics={
+                "curiosity": 0.7,
+                "You want to feel safe.": 0.4,
+            },
+            string_metrics={"time_phase": "night"},
+            params={"time_phase": "night"},
+            private=False,
+            message="ok",
+        )
+    )
+    store.ingest(_event(1, "remember", 0.3, "night"))
+
+    current = store.current()
+
+    assert current["latest_desires"] == {"curiosity": 0.7}
+    assert current["latest_emergent_desires"] == {"You want to feel safe.": 0.4}
+    assert store.desire_metric_keys(start, start + timedelta(minutes=10)) == [
+        "You want to feel safe.",
+        "curiosity",
+    ]
+
+
 def test_desire_metrics_follow_catalog_and_hide_removed_legacy_fixed_desires() -> None:
     store = TelemetryStore(
         desire_catalog=_catalog(

--- a/dashboard/tests/test_store.py
+++ b/dashboard/tests/test_store.py
@@ -285,6 +285,32 @@ def test_current_and_desire_metric_keys_accept_attune_events() -> None:
     ]
 
 
+def test_invoked_attune_event_not_counted_for_desire_metrics() -> None:
+    """Invoked events should not contribute desire metrics (Finding 6)."""
+    store = TelemetryStore()
+    start = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    # Invoked event has numeric_metrics but should be ignored for desires
+    store.ingest(
+        DashboardEvent(
+            ts=start,
+            event_type="tool_call_invoked",
+            tool_name="attune",
+            ok=True,
+            duration_ms=0,
+            emotion_primary="",
+            emotion_intensity=0.0,
+            numeric_metrics={"curiosity": 0.99},
+            string_metrics={},
+            params={},
+            private=False,
+            message="",
+        )
+    )
+    current = store.current()
+    assert current["latest_desires"] == {}
+    assert store.desire_metric_keys(start, start + timedelta(minutes=10)) == []
+
+
 def test_desire_metrics_follow_catalog_and_hide_removed_legacy_fixed_desires() -> None:
     store = TelemetryStore(
         desire_catalog=_catalog(

--- a/ego-mcp/README.md
+++ b/ego-mcp/README.md
@@ -150,6 +150,7 @@ Top-level keys:
 | `satisfaction_hours` | number | Yes | Recovery time constant for emergent desires after they are satisfied. Must be greater than `0`. |
 | `expiry_hours` | number | Yes | How long an emergent desire can remain unsatisfied before it is considered stale and removed. Must be greater than `0`. |
 | `satisfied_ttl_hours` | number | Yes | How long a satisfied emergent desire is retained before being removed from state. Must be greater than `0`. |
+| `min_recent_memories` | integer | No | Minimum number of recent memories within the time window required to trigger an emergent desire from short-term emotion flow. Default `3`. Must be `>= 1`. |
 
 Validation and parsing rules:
 

--- a/ego-mcp/README.md
+++ b/ego-mcp/README.md
@@ -318,7 +318,7 @@ uv run mypy src/ego_mcp/
 ### Upgrading from v0.6.x
 
 See [docs/migration-v1.0.0.md](docs/migration-v1.0.0.md) for the v0.6.x → v1.0.0 migration guide.
-The server runs automatic migrations on startup. If you have a customized `settings/desires.json`, you may need to manually set `settling` sentence templates and `satisfaction_signals` via `configure_desires(action="check")`.
+The server runs automatic migrations on startup. If you have a customized `settings/desires.json`, use `configure_desires(action="check")` to find missing fields, then fill them with `configure_desires(action="set_sentence", ...)` and `configure_desires(action="set_signals", ...)`.
 
 ### `hashlib blake2*` error when running `uv`
 

--- a/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
@@ -153,10 +153,11 @@ def _set_sentence(
     if direction not in ("rising", "steady", "settling"):
         return f"Invalid direction: {direction}. Use rising, steady, or settling."
 
-    desires[desire_id].setdefault("sentence", {})
-    if not isinstance(desires[desire_id]["sentence"], dict):
-        desires[desire_id]["sentence"] = {}
-    payload["fixed_desires"][desire_id]["sentence"][direction] = sentence
+    desire = desires[desire_id]
+    desire.setdefault("sentence", {})
+    if not isinstance(desire["sentence"], dict):
+        desire["sentence"] = {}
+    desire["sentence"][direction] = sentence
     _write_payload(path, payload)
     return _write_result(path, f"Updated {desire_id}.sentence.{direction}")
 
@@ -171,7 +172,7 @@ def _set_signals(
     if desire_id not in desires:
         return f"Unknown desire: {desire_id}"
 
-    payload["fixed_desires"][desire_id]["satisfaction_signals"] = signals
+    desires[desire_id]["satisfaction_signals"] = signals
     _write_payload(path, payload)
     return _write_result(
         path,

--- a/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from ego_mcp.desire_catalog import (
-    DesireCatalog,
+    DesireConfigurationError,
+    ensure_default_desire_catalog_file,
     load_desire_catalog,
 )
 
@@ -16,21 +18,23 @@ def _handle_configure_desires(
     args: dict[str, Any],
 ) -> str:
     """View or configure desire settings."""
-    from pathlib import Path
-
     path = Path(catalog_path)
-    catalog = load_desire_catalog(path)
-
+    payload = _load_catalog_payload(path)
     action = str(args.get("action", "")).strip()
+    catalog_error: str | None = None
+    try:
+        load_desire_catalog(path)
+    except DesireConfigurationError as exc:
+        catalog_error = str(exc)
 
     if action == "show":
         desire_id = args.get("desire_id")
         if desire_id:
-            return _show_one(catalog, str(desire_id))
-        return _show_all(catalog)
+            return _show_one(payload, str(desire_id), catalog_error=catalog_error)
+        return _show_all(payload, catalog_error=catalog_error)
 
     if action == "check":
-        return _check_incomplete(catalog)
+        return _check_incomplete(payload, catalog_error=catalog_error)
 
     if action == "set_sentence":
         desire_id = str(args.get("desire_id", "")).strip()
@@ -38,105 +42,153 @@ def _handle_configure_desires(
         sentence = str(args.get("sentence", "")).strip()
         if not desire_id or not direction or not sentence:
             return "set_sentence requires desire_id, direction, and sentence."
-        return _set_sentence(path, catalog, desire_id, direction, sentence)
+        return _set_sentence(path, payload, desire_id, direction, sentence)
 
     if action == "set_signals":
         desire_id = str(args.get("desire_id", "")).strip()
         signals = args.get("signals")
         if not desire_id or not isinstance(signals, list):
             return "set_signals requires desire_id and signals (list of strings)."
-        return _set_signals(path, catalog, desire_id, [str(s) for s in signals])
+        return _set_signals(path, payload, desire_id, [str(s) for s in signals])
 
     return f"Unknown action: {action}. Use check, show, set_sentence, or set_signals."
 
 
-def _show_one(catalog: DesireCatalog, desire_id: str) -> str:
-    desire = catalog.fixed_desires.get(desire_id)
+def _load_catalog_payload(path: Path) -> dict[str, Any]:
+    ensure_default_desire_catalog_file(path)
+    with open(path, encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise DesireConfigurationError(f"Invalid desire catalog at {path}: root must be an object")
+    return payload
+
+
+def _fixed_desire_payloads(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    fixed = payload.get("fixed_desires", {})
+    if not isinstance(fixed, dict):
+        return {}
+    return {
+        desire_id: raw
+        for desire_id, raw in fixed.items()
+        if isinstance(desire_id, str) and isinstance(raw, dict)
+    }
+
+
+def _show_one(
+    payload: dict[str, Any],
+    desire_id: str,
+    *,
+    catalog_error: str | None = None,
+) -> str:
+    desires = _fixed_desire_payloads(payload)
+    desire = desires.get(desire_id)
     if desire is None:
-        known = ", ".join(sorted(catalog.fixed_desires.keys()))
+        known = ", ".join(sorted(desires.keys()))
         return f"Unknown desire: {desire_id}. Known: {known}"
+    sentence = desire.get("sentence", {})
+    if not isinstance(sentence, dict):
+        sentence = {}
     lines = [
         f"Desire: {desire_id}",
-        f"  satisfaction_hours: {desire.satisfaction_hours}",
-        f"  maslow_level: {desire.maslow_level}",
-        f"  sentence.rising: {desire.sentence.rising!r}",
-        f"  sentence.steady: {desire.sentence.steady!r}",
-        f"  sentence.settling: {desire.sentence.settling!r}",
+        f"  satisfaction_hours: {desire.get('satisfaction_hours', '(missing)')}",
+        f"  maslow_level: {desire.get('maslow_level', '(missing)')}",
+        f"  sentence.rising: {sentence.get('rising', '')!r}",
+        f"  sentence.steady: {sentence.get('steady', '')!r}",
+        f"  sentence.settling: {sentence.get('settling', '')!r}",
     ]
-    if desire.satisfaction_signals:
-        lines.append(f"  satisfaction_signals: {desire.satisfaction_signals}")
+    signals = desire.get("satisfaction_signals", [])
+    if isinstance(signals, list) and signals:
+        lines.append(f"  satisfaction_signals: {signals}")
     else:
         lines.append("  satisfaction_signals: (not configured)")
-    if desire.implicit_satisfaction:
-        lines.append(f"  implicit_satisfaction: {desire.implicit_satisfaction}")
+    implicit = desire.get("implicit_satisfaction", {})
+    if isinstance(implicit, dict) and implicit:
+        lines.append(f"  implicit_satisfaction: {implicit}")
+    if catalog_error is not None:
+        lines.append(f"  validation: {catalog_error}")
     return "\n".join(lines)
 
 
-def _show_all(catalog: DesireCatalog) -> str:
-    lines = [f"Desire catalog (version {catalog.version}):"]
-    for desire_id, desire in sorted(catalog.fixed_desires.items()):
+def _show_all(payload: dict[str, Any], *, catalog_error: str | None = None) -> str:
+    lines = [f"Desire catalog (version {payload.get('version', '(missing)')}):"]
+    for desire_id, desire in sorted(_fixed_desire_payloads(payload).items()):
         incomplete = []
-        if not desire.sentence.settling:
+        sentence = desire.get("sentence", {})
+        if not isinstance(sentence, dict) or not sentence.get("settling"):
             incomplete.append("settling")
-        if not desire.satisfaction_signals:
+        if not desire.get("satisfaction_signals"):
             incomplete.append("signals")
         status = " [incomplete: " + ", ".join(incomplete) + "]" if incomplete else ""
-        lines.append(f"  {desire_id}: maslow={desire.maslow_level}{status}")
+        lines.append(f"  {desire_id}: maslow={desire.get('maslow_level', '(missing)')}{status}")
+    if catalog_error is not None:
+        lines.append(f"Validation issues: {catalog_error}")
     return "\n".join(lines)
 
 
-def _check_incomplete(catalog: DesireCatalog) -> str:
+def _check_incomplete(payload: dict[str, Any], *, catalog_error: str | None = None) -> str:
     issues: list[str] = []
-    for desire_id, desire in sorted(catalog.fixed_desires.items()):
-        if not desire.sentence.settling:
+    for desire_id, desire in sorted(_fixed_desire_payloads(payload).items()):
+        sentence = desire.get("sentence", {})
+        if not isinstance(sentence, dict) or not sentence.get("settling"):
             issues.append(f"  {desire_id}: missing settling sentence")
-        if not desire.satisfaction_signals:
+        if not desire.get("satisfaction_signals"):
             issues.append(f"  {desire_id}: missing satisfaction_signals")
+    if catalog_error is not None:
+        issues.insert(0, f"  validation: {catalog_error}")
     if not issues:
         return "All desires are fully configured."
     return "Incomplete configuration:\n" + "\n".join(issues)
 
 
 def _set_sentence(
-    path: "Any",
-    catalog: DesireCatalog,
+    path: Path,
+    payload: dict[str, Any],
     desire_id: str,
     direction: str,
     sentence: str,
 ) -> str:
-    from pathlib import Path
-
-    desire = catalog.fixed_desires.get(desire_id)
-    if desire is None:
+    desires = _fixed_desire_payloads(payload)
+    if desire_id not in desires:
         return f"Unknown desire: {desire_id}"
     if direction not in ("rising", "steady", "settling"):
         return f"Invalid direction: {direction}. Use rising, steady, or settling."
 
-    payload = catalog.model_dump(mode="json", exclude_none=True)
+    desires[desire_id].setdefault("sentence", {})
+    if not isinstance(desires[desire_id]["sentence"], dict):
+        desires[desire_id]["sentence"] = {}
     payload["fixed_desires"][desire_id]["sentence"][direction] = sentence
-    Path(path).write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-    return f"Updated {desire_id}.sentence.{direction}"
+    _write_payload(path, payload)
+    return _write_result(path, f"Updated {desire_id}.sentence.{direction}")
 
 
 def _set_signals(
-    path: "Any",
-    catalog: DesireCatalog,
+    path: Path,
+    payload: dict[str, Any],
     desire_id: str,
     signals: list[str],
 ) -> str:
-    from pathlib import Path
-
-    desire = catalog.fixed_desires.get(desire_id)
-    if desire is None:
+    desires = _fixed_desire_payloads(payload)
+    if desire_id not in desires:
         return f"Unknown desire: {desire_id}"
 
-    payload = catalog.model_dump(mode="json", exclude_none=True)
     payload["fixed_desires"][desire_id]["satisfaction_signals"] = signals
-    Path(path).write_text(
+    _write_payload(path, payload)
+    return _write_result(
+        path,
+        f"Updated {desire_id}.satisfaction_signals ({len(signals)} signal(s))",
+    )
+
+
+def _write_payload(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
-    return f"Updated {desire_id}.satisfaction_signals ({len(signals)} signal(s))"
+
+
+def _write_result(path: Path, success_message: str) -> str:
+    try:
+        load_desire_catalog(path)
+    except DesireConfigurationError as exc:
+        return f"{success_message}\nCatalog still has validation issues: {exc}"
+    return success_message

--- a/ego-mcp/src/ego_mcp/_server_surface_attune.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_attune.py
@@ -14,7 +14,7 @@ from ego_mcp._server_runtime import (
 )
 from ego_mcp.config import EgoConfig
 from ego_mcp.current_interest import derive_current_interests
-from ego_mcp.desire import DesireEngine
+from ego_mcp.desire import DesireEngine, generate_emergent_from_recent_memories
 from ego_mcp.desire_blend import blend_desires
 from ego_mcp.emergent_desires import emergent_desire_sentence
 from ego_mcp.interoception import get_body_state
@@ -83,8 +83,12 @@ async def _handle_attune(
     emotional_texture = _format_recent_emotion_layer(recent_all, now=now)
 
     # 2. Desire currents (3-direction with EMA)
-    created_emergent = desire.generate_emergent_desires(_list_notions_safe())
     expired_emergent = desire.expire_emergent_desires()
+    created_emergent: list[str] = []
+    recent_emergent = generate_emergent_from_recent_memories(desire, recent_all)
+    if recent_emergent is not None:
+        created_emergent.append(recent_emergent)
+    created_emergent.extend(desire.generate_emergent_desires(_list_notions_safe()))
 
     from ego_mcp._server_context import (
         _derive_desire_modulation,

--- a/ego-mcp/src/ego_mcp/_server_surface_core.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_core.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from ego_mcp import timezone_utils
@@ -129,6 +132,46 @@ def _list_notions_safe() -> list[Notion]:
     return list(_notion_map().values())
 
 
+_logger = logging.getLogger(__name__)
+
+_CONFIDENCE_DROP_THRESHOLD = 0.1
+
+
+def _detect_weakened_notions(
+    current_notions: list[Notion],
+    snapshot_path: Path,
+) -> list[Notion]:
+    """Return notions whose confidence dropped >= threshold since last snapshot.
+
+    Saves the current confidence values for next comparison.
+    """
+    previous: dict[str, float] = {}
+    if snapshot_path.exists():
+        try:
+            previous = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not isinstance(previous, dict):
+        previous = {}
+
+    weakened: list[Notion] = []
+    for n in current_notions:
+        prev_conf = previous.get(n.id)
+        if prev_conf is not None and prev_conf - n.confidence >= _CONFIDENCE_DROP_THRESHOLD:
+            weakened.append(n)
+
+    current_snapshot = {n.id: n.confidence for n in current_notions}
+    try:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(
+            json.dumps(current_snapshot), encoding="utf-8"
+        )
+    except OSError:
+        _logger.debug("Failed to save notion confidence snapshot", exc_info=True)
+
+    return weakened
+
+
 def _format_associated_from_map(
     notion: Notion,
     notion_map: dict[str, Notion],
@@ -227,9 +270,7 @@ async def _handle_wake_up(
     now = timezone_utils.now()
     recent_all = await memory.list_recent(n=30)
     parts: list[str] = []
-    expire_emergent = getattr(desire, "expire_emergent_desires", None)
-    if callable(expire_emergent):
-        expire_emergent()
+    desire.expire_emergent_desires()
 
     # 1. Emotional texture of last session
     if recent_all:
@@ -242,9 +283,9 @@ async def _handle_wake_up(
         for name, state in desire._state.items()
         if isinstance(state, dict) and state.get("is_emergent", False)
     ]
-    weakened_notions = [
-        n for n in _list_notions_safe() if n.confidence < 0.4
-    ]
+    all_notions = _list_notions_safe()
+    snapshot_path = config.data_dir / "notion_confidence_snapshot.json"
+    weakened_notions = _detect_weakened_notions(all_notions, snapshot_path)
     try:
         unresolved_qs = _fading_important_questions(memory)
     except Exception:

--- a/ego-mcp/src/ego_mcp/_server_surface_core.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_core.py
@@ -227,6 +227,9 @@ async def _handle_wake_up(
     now = timezone_utils.now()
     recent_all = await memory.list_recent(n=30)
     parts: list[str] = []
+    expire_emergent = getattr(desire, "expire_emergent_desires", None)
+    if callable(expire_emergent):
+        expire_emergent()
 
     # 1. Emotional texture of last session
     if recent_all:

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -301,12 +301,15 @@ async def _handle_remember(
                 s.strip() for s in satisfies_raw if isinstance(s, str) and s.strip()
             ]
         if satisfies_explicit:
+            satisfied_any = False
             for desire_id in satisfies_explicit:
                 try:
                     desire_engine.satisfy(desire_id, quality=0.5)
+                    satisfied_any = True
                 except ValueError:
                     logger.warning("Unknown desire in satisfies: %s", desire_id)
-            desire_settling_section = "Putting this into words eased something."
+            if satisfied_any:
+                desire_settling_section = "Putting this into words eased something."
         elif embed_fn is not None:
             catalog = getattr(desire_engine, "catalog", None)
             if catalog is not None:

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -300,17 +300,17 @@ async def _handle_remember(
             satisfies_explicit = [
                 s.strip() for s in satisfies_raw if isinstance(s, str) and s.strip()
             ]
+        explicit_success = False
         if satisfies_explicit:
-            satisfied_any = False
             for desire_id in satisfies_explicit:
                 try:
                     desire_engine.satisfy(desire_id, quality=0.5)
-                    satisfied_any = True
+                    explicit_success = True
                 except ValueError:
                     logger.warning("Unknown desire in satisfies: %s", desire_id)
-            if satisfied_any:
+            if explicit_success:
                 desire_settling_section = "Putting this into words eased something."
-        elif embed_fn is not None:
+        if not explicit_success and embed_fn is not None:
             catalog = getattr(desire_engine, "catalog", None)
             if catalog is not None:
                 inferred = infer_desire_satisfaction(

--- a/ego-mcp/src/ego_mcp/desire.py
+++ b/ego-mcp/src/ego_mcp/desire.py
@@ -83,15 +83,25 @@ def generate_emergent_from_recent_memories(
     engine: DesireEngine,
     memories: list[Memory],
     window_hours: float = 6.0,
-    min_memories: int = 3,
+    min_memories: int | None = None,
 ) -> str | None:
     """Generate an emergent desire from a short-term emotion flow.
 
     Analyses recent memories within *window_hours*, finds the dominant
     emotion + average valence, and maps it to an emergent desire.
     Returns the desire ID if created, or ``None``.
+
+    *min_memories* defaults to ``catalog.emergent.min_recent_memories``
+    (3 if the catalog is unavailable).
     """
     from collections import Counter
+
+    if min_memories is None:
+        try:
+            catalog = engine.require_valid_catalog()
+            min_memories = catalog.emergent.min_recent_memories
+        except Exception:
+            min_memories = 3
 
     now = timezone_utils.now()
     recent: list[Memory] = []

--- a/ego-mcp/src/ego_mcp/desire_catalog.py
+++ b/ego-mcp/src/ego_mcp/desire_catalog.py
@@ -164,6 +164,7 @@ DEFAULT_EMERGENT = {
     "satisfaction_hours": 24.0,
     "expiry_hours": 72.0,
     "satisfied_ttl_hours": 24.0 * 7,
+    "min_recent_memories": 3,
 }
 
 
@@ -245,6 +246,7 @@ class EmergentDesireConfig(BaseModel):
     satisfaction_hours: float = Field(gt=0)
     expiry_hours: float = Field(gt=0)
     satisfied_ttl_hours: float = Field(gt=0)
+    min_recent_memories: int = Field(default=3, ge=1)
 
 
 class DesireCatalog(BaseModel):

--- a/ego-mcp/tests/test_attune.py
+++ b/ego-mcp/tests/test_attune.py
@@ -16,7 +16,7 @@ from ego_mcp._server_surface_attune import (
 )
 from ego_mcp.config import EgoConfig
 from ego_mcp.desire import DesireEngine
-from ego_mcp.types import Category, Memory
+from ego_mcp.types import Category, Emotion, EmotionalTrace, Memory
 
 
 @pytest.fixture
@@ -133,6 +133,34 @@ class TestHandleAttune:
         """Lines 160-162: emergent_desire_sentence returns a sentence."""
         engine._state["be_with_someone"] = {"is_emergent": True}
         result = await _handle_attune(config, memory, engine)
+        assert "Emergent pull:" in result
+        assert "You want to be with someone." in result
+
+    @pytest.mark.asyncio
+    async def test_recent_memories_can_trigger_emergent_pull_without_notions(
+        self,
+        config: EgoConfig,
+        memory: AsyncMock,
+        engine: DesireEngine,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        sad_memories = [
+            Memory(
+                id=f"m{i}",
+                content="feeling alone tonight",
+                timestamp=(now - timedelta(hours=i + 1)).isoformat(),
+                emotional_trace=EmotionalTrace(
+                    primary=Emotion.SAD,
+                    valence=-0.6,
+                    intensity=0.7,
+                ),
+            )
+            for i in range(3)
+        ]
+        memory.list_recent = AsyncMock(return_value=sad_memories)
+
+        result = await _handle_attune(config, memory, engine)
+
         assert "Emergent pull:" in result
         assert "You want to be with someone." in result
 

--- a/ego-mcp/tests/test_configure_desires.py
+++ b/ego-mcp/tests/test_configure_desires.py
@@ -111,3 +111,40 @@ class TestConfigureDesires:
             },
         )
         assert "Unknown desire: nonexistent" in result
+
+    def test_check_still_reports_issues_when_catalog_is_invalid(
+        self, catalog_path: Path
+    ) -> None:
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        payload["fixed_desires"]["curiosity"]["sentence"]["settling"] = ""
+        payload["fixed_desires"]["curiosity"]["implicit_satisfaction"]["recall"] = 2.0
+        catalog_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        result = _handle_configure_desires(str(catalog_path), {"action": "check"})
+
+        assert "validation:" in result
+        assert "curiosity: missing settling sentence" in result
+
+    def test_set_sentence_can_edit_invalid_catalog(self, catalog_path: Path) -> None:
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        payload["fixed_desires"]["curiosity"]["implicit_satisfaction"]["recall"] = 2.0
+        catalog_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_sentence",
+                "desire_id": "curiosity",
+                "direction": "settling",
+                "sentence": "Quiet again.",
+            },
+        )
+
+        assert "Updated curiosity.sentence.settling" in result
+        assert "Catalog still has validation issues:" in result
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        assert payload["fixed_desires"]["curiosity"]["sentence"]["settling"] == "Quiet again."

--- a/ego-mcp/tests/test_desire.py
+++ b/ego-mcp/tests/test_desire.py
@@ -786,3 +786,32 @@ class TestGenerateEmergentFromRecentMemories:
         ]
         result = generate_emergent_from_recent_memories(engine, mems)
         assert result is None
+
+    def test_reads_min_recent_memories_from_catalog(self, tmp_path: Path) -> None:
+        """min_memories defaults to catalog.emergent.min_recent_memories."""
+        catalog = default_desire_catalog()
+        payload = catalog.model_dump(mode="json", exclude_none=True)
+        payload["emergent"]["min_recent_memories"] = 2
+        settings_dir = tmp_path / "settings"
+        settings_dir.mkdir()
+        (settings_dir / "desires.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        engine = DesireEngine.from_data_dir(tmp_path)
+        # Only 2 memories — would fail with default min_memories=3, but succeeds with 2
+        mems = [
+            _memory_with_emotion(Emotion.SAD, -0.5, hours_ago=1),
+            _memory_with_emotion(Emotion.SAD, -0.5, hours_ago=2),
+        ]
+        result = generate_emergent_from_recent_memories(engine, mems)
+        assert result is not None
+
+    def test_explicit_min_memories_overrides_catalog(self, tmp_path: Path) -> None:
+        engine = DesireEngine.from_data_dir(tmp_path)
+        mems = [
+            _memory_with_emotion(Emotion.SAD, -0.5, hours_ago=1),
+            _memory_with_emotion(Emotion.SAD, -0.5, hours_ago=2),
+        ]
+        # Explicit override to 2 — should succeed
+        result = generate_emergent_from_recent_memories(engine, mems, min_memories=2)
+        assert result is not None

--- a/ego-mcp/tests/test_server.py
+++ b/ego-mcp/tests/test_server.py
@@ -987,6 +987,7 @@ class TestWakeUpServerHandler:
     async def test_handle_wake_up_prefers_workspace_monologue(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         class FakeSync:
             def read_latest_monologue(self) -> tuple[str | None, str | None]:
@@ -1009,6 +1010,9 @@ class TestWakeUpServerHandler:
             def compute_levels_with_modulation(self) -> dict[str, float]:
                 return {"curiosity": 0.8}
 
+            def expire_emergent_desires(self) -> list[str]:
+                return []
+
         async def fake_relationship_snapshot(
             _config: object, _memory: object, _person: str
         ) -> str:
@@ -1019,7 +1023,7 @@ class TestWakeUpServerHandler:
         monkeypatch.setattr(server_mod, "_relationship_snapshot", fake_relationship_snapshot)
 
         text = await server_mod._handle_wake_up(
-            cast(Any, SimpleNamespace(companion_name="Master")),
+            cast(Any, SimpleNamespace(companion_name="Master", data_dir=tmp_path)),
             cast(Any, FakeMemoryStore()),
             cast(Any, FakeDesire()),
         )
@@ -1038,6 +1042,7 @@ class TestWakeUpServerHandler:
     async def test_handle_wake_up_falls_back_to_recent_introspection(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         class FakeSync:
             def read_latest_monologue(self) -> tuple[str | None, str | None]:
@@ -1068,6 +1073,9 @@ class TestWakeUpServerHandler:
             def compute_levels_with_modulation(self) -> dict[str, float]:
                 return {"cognitive_coherence": 0.75}
 
+            def expire_emergent_desires(self) -> list[str]:
+                return []
+
         async def fake_relationship_snapshot(
             _config: object, _memory: object, _person: str
         ) -> str:
@@ -1078,7 +1086,7 @@ class TestWakeUpServerHandler:
         monkeypatch.setattr(server_mod, "_relationship_snapshot", fake_relationship_snapshot)
 
         text = await server_mod._handle_wake_up(
-            cast(Any, SimpleNamespace(companion_name="Master")),
+            cast(Any, SimpleNamespace(companion_name="Master", data_dir=tmp_path)),
             cast(Any, FakeMemoryStore()),
             cast(Any, FakeDesire()),
         )
@@ -1092,6 +1100,7 @@ class TestWakeUpServerHandler:
     async def test_handle_wake_up_without_any_introspection(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         class FakeSync:
             def read_latest_monologue(self) -> tuple[str | None, str | None]:
@@ -1111,6 +1120,9 @@ class TestWakeUpServerHandler:
             def compute_levels_with_modulation(self) -> dict[str, float]:
                 return {"expression": 0.45}
 
+            def expire_emergent_desires(self) -> list[str]:
+                return []
+
         async def fake_relationship_snapshot(
             _config: object, _memory: object, _person: str
         ) -> str:
@@ -1121,7 +1133,7 @@ class TestWakeUpServerHandler:
         monkeypatch.setattr(server_mod, "_relationship_snapshot", fake_relationship_snapshot)
 
         text = await server_mod._handle_wake_up(
-            cast(Any, SimpleNamespace(companion_name="Master")),
+            cast(Any, SimpleNamespace(companion_name="Master", data_dir=tmp_path)),
             cast(Any, FakeMemoryStore()),
             cast(Any, FakeDesire()),
         )

--- a/ego-mcp/tests/test_server_surface_memory.py
+++ b/ego-mcp/tests/test_server_surface_memory.py
@@ -250,6 +250,45 @@ class TestHandleRememberDesireSatisfaction:
         assert "Putting this into words eased something." not in result
 
     @pytest.mark.asyncio
+    async def test_failed_explicit_satisfies_falls_through_to_auto_inference(
+        self,
+        remember_config: EgoConfig,
+        mock_memory: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When all explicit satisfies IDs are invalid, fall back to auto-inference."""
+        engine = DesireEngine.from_data_dir(remember_config.data_dir)
+        catalog = engine.require_valid_catalog()
+        target_desire = next(iter(catalog.fixed_desires.keys()))
+
+        import ego_mcp._server_surface_memory as mem_mod
+
+        monkeypatch.setattr(
+            mem_mod,
+            "infer_desire_satisfaction",
+            lambda content, valence, intensity, cat, fn: [(target_desire, 0.4)],
+        )
+
+        def fake_embed(texts: list[str]) -> list[list[float]]:
+            return [[0.1] * 64 for _ in texts]
+
+        result = await _handle_remember(
+            remember_config,
+            mock_memory,
+            {
+                "content": "A wonderful moment",
+                "emotion": "happy",
+                "satisfies": ["nonexistent_desire_xyz"],
+            },
+            desire_engine=engine,
+            embed_fn=fake_embed,
+        )
+        assert "Saved (" in result
+        # Explicit failed → fell through to auto-inference → success message
+        assert "Something quieted" in result
+        assert "Putting this into words eased something." not in result
+
+    @pytest.mark.asyncio
     async def test_auto_infer_satisfaction_with_embed_fn(
         self,
         remember_config: EgoConfig,

--- a/ego-mcp/tests/test_server_surface_memory.py
+++ b/ego-mcp/tests/test_server_surface_memory.py
@@ -247,6 +247,7 @@ class TestHandleRememberDesireSatisfaction:
             )
         assert "Saved (" in result
         assert "Unknown desire in satisfies" in caplog.text
+        assert "Putting this into words eased something." not in result
 
     @pytest.mark.asyncio
     async def test_auto_infer_satisfaction_with_embed_fn(

--- a/ego-mcp/tests/test_wake_up.py
+++ b/ego-mcp/tests/test_wake_up.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -129,3 +130,21 @@ class TestHandleWakeUp:
         result = await _handle_wake_up(config, memory, engine)
         # With no memories, embers section should not appear
         assert "Embers:" not in result
+
+    @pytest.mark.asyncio
+    async def test_stale_emergent_desire_not_rendered(
+        self, config: EgoConfig, memory: AsyncMock, engine: DesireEngine
+    ) -> None:
+        engine._state["be_with_someone"] = {
+            "is_emergent": True,
+            "created": (datetime.now(timezone.utc) - timedelta(days=10)).isoformat(),
+            "last_satisfied": "",
+            "satisfaction_quality": 0.5,
+            "boost": 0.0,
+            "satisfaction_hours": 24.0,
+        }
+
+        result = await _handle_wake_up(config, memory, engine)
+
+        assert "...be with someone" not in result
+        assert "You want to be with someone." not in result

--- a/ego-mcp/tests/test_wake_up.py
+++ b/ego-mcp/tests/test_wake_up.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -9,9 +10,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ego_mcp._server_surface_core import _handle_wake_up
+from ego_mcp._server_surface_core import (
+    _detect_weakened_notions,
+    _handle_wake_up,
+)
 from ego_mcp.config import EgoConfig
 from ego_mcp.desire import DesireEngine
+from ego_mcp.types import Notion
 
 
 @pytest.fixture
@@ -148,3 +153,46 @@ class TestHandleWakeUp:
 
         assert "...be with someone" not in result
         assert "You want to be with someone." not in result
+
+
+class TestDetectWeakenedNotions:
+    def test_no_previous_snapshot_returns_empty(self, tmp_path: Path) -> None:
+        snapshot = tmp_path / "snap.json"
+        notions = [Notion(id="n1", confidence=0.3)]
+        result = _detect_weakened_notions(notions, snapshot)
+        assert result == []
+
+    def test_detects_confidence_drop(self, tmp_path: Path) -> None:
+        snapshot = tmp_path / "snap.json"
+        snapshot.write_text(json.dumps({"n1": 0.8, "n2": 0.5}))
+        notions = [
+            Notion(id="n1", confidence=0.6),  # dropped 0.2 >= 0.1
+            Notion(id="n2", confidence=0.45),  # dropped 0.05 < 0.1
+        ]
+        result = _detect_weakened_notions(notions, snapshot)
+        assert len(result) == 1
+        assert result[0].id == "n1"
+
+    def test_saves_current_snapshot(self, tmp_path: Path) -> None:
+        snapshot = tmp_path / "snap.json"
+        notions = [Notion(id="n1", confidence=0.7)]
+        _detect_weakened_notions(notions, snapshot)
+        saved = json.loads(snapshot.read_text())
+        assert saved == {"n1": 0.7}
+
+    def test_corrupted_snapshot_treated_as_empty(self, tmp_path: Path) -> None:
+        snapshot = tmp_path / "snap.json"
+        snapshot.write_text("not json")
+        notions = [Notion(id="n1", confidence=0.3)]
+        result = _detect_weakened_notions(notions, snapshot)
+        assert result == []
+
+    def test_notion_removed_since_last_snapshot(self, tmp_path: Path) -> None:
+        snapshot = tmp_path / "snap.json"
+        snapshot.write_text(json.dumps({"n1": 0.8, "n2": 0.9}))
+        # n2 no longer present
+        notions = [Notion(id="n1", confidence=0.8)]
+        result = _detect_weakened_notions(notions, snapshot)
+        assert result == []
+        saved = json.loads(snapshot.read_text())
+        assert "n2" not in saved


### PR DESCRIPTION
## Summary
Fixes the issues found while reviewing PR #26 against `design/wip/redesign-attune.md`.

This branch makes the redesign behavior actually reachable in production, prevents stale emergent state from leaking into responses, removes a false-positive success path in `remember`, restores the in-band repair path for broken desire catalogs, and corrects the migration guidance in the README.

## Findings Addressed
- `attune` only generated emergent desires from notions, so the redesign's recent-memory trigger never reached production.
- `wake_up` collected active emergent desires before stale entries were expired, so expired desires could still appear in the same response that aged them out.
- `remember(..., satisfies=[...])` always appended the easing/success sentence even when every supplied desire ID was invalid.
- `configure_desires` validated the full catalog before dispatching on action, so `check`, `show`, and repair actions became unusable exactly when the catalog was already invalid.
- The README migration note incorrectly implied `configure_desires(action="check")` could fill missing fields.

## Fixes
- Wire `generate_emergent_from_recent_memories(...)` into `attune`, with emergent expiration happening before new generation.
- Expire emergent desires before `wake_up` snapshots the active emergent state for the response.
- Only emit the settling/easing sentence in `remember` when at least one explicit satisfaction actually succeeds.
- Rework `configure_desires` to operate on raw catalog payloads for read/repair actions and report validation issues in-band instead of hard-failing.
- Update the README migration instructions to point users at `set_sentence` and `set_signals` for repair.

## Tests And Validation
- Added coverage for recent-memory emergent generation without notions.
- Added coverage that stale emergent desires do not render in `wake_up`.
- Added coverage that invalid explicit `satisfies` IDs do not show a success message.
- Added coverage that `configure_desires` can still report and repair invalid catalogs.
- Ran the full `ego-mcp` quality gate:
  - `cd ego-mcp && uv sync --extra dev`
  - `cd ego-mcp && GEMINI_API_KEY=test-key uv run pytest tests -v`
  - `cd ego-mcp && uv run isort --check-only src tests`
  - `cd ego-mcp && uv run ruff check src tests`
  - `cd ego-mcp && uv run mypy src tests`

Pytest result: `721 passed, 3 warnings`.