### PR TITLE
Cache satisfaction-signal embeddings to disk

### DIFF
--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "1.0.0"
+version = "1.0.1"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.14"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -27,7 +27,7 @@ from ego_mcp._server_runtime import (
 )
 from ego_mcp.config import EgoConfig
 from ego_mcp.desire import DesireEngine
-from ego_mcp.desire_satisfaction import infer_desire_satisfaction
+from ego_mcp.desire_satisfaction import SignalEmbeddingCache, infer_desire_satisfaction
 from ego_mcp.interoception import get_body_state
 from ego_mcp.memory import MemoryStore
 from ego_mcp.notion import update_notion_from_memory
@@ -136,6 +136,7 @@ async def _handle_remember(
     *,
     desire_engine: DesireEngine | None = None,
     embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
+    signal_cache: SignalEmbeddingCache | None = None,
 ) -> str:
     """Save a memory with auto-linking."""
     _set_tool_context("remember", {})
@@ -314,7 +315,8 @@ async def _handle_remember(
             catalog = getattr(desire_engine, "catalog", None)
             if catalog is not None:
                 inferred = infer_desire_satisfaction(
-                    content, valence, intensity, catalog, embed_fn
+                    content, valence, intensity, catalog, embed_fn,
+                    signal_cache=signal_cache,
                 )
                 for desire_id, quality in inferred:
                     try:

--- a/ego-mcp/src/ego_mcp/desire_satisfaction.py
+++ b/ego-mcp/src/ego_mcp/desire_satisfaction.py
@@ -8,10 +8,16 @@ satisfied with quality = similarity * 0.5.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 import math
 from collections.abc import Callable
+from pathlib import Path
 
 from ego_mcp.desire_catalog import DesireCatalog
+
+logger = logging.getLogger(__name__)
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -27,12 +33,97 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 _SIMILARITY_THRESHOLD = 0.6
 
 
+class SignalEmbeddingCache:
+    """Caches satisfaction-signal embeddings to disk.
+
+    Signal texts are derived from the desire catalog and rarely change.
+    By persisting their embeddings, ``remember`` only needs to embed the
+    content text (1 API call) instead of content + all signals.
+
+    The cache is keyed by a SHA-256 fingerprint of the sorted signal texts.
+    When the catalog changes (via ``configure_desires`` or direct edit of
+    ``desires.json``), the fingerprint misses and embeddings are recomputed.
+    """
+
+    def __init__(self, cache_path: Path) -> None:
+        self._path = cache_path
+        self._fingerprint: str = ""
+        self._signals: list[tuple[str, str]] = []
+        self._embeddings: list[list[float]] = []
+        self._load()
+
+    # -- public API --------------------------------------------------
+
+    def get(
+        self,
+        catalog: DesireCatalog,
+        embed_fn: Callable[[list[str]], list[list[float]]],
+    ) -> tuple[list[tuple[str, str]], list[list[float]]]:
+        """Return (signals, embeddings), using cache when possible."""
+        fp = _compute_fingerprint(catalog)
+        if fp == self._fingerprint and self._embeddings:
+            return self._signals, self._embeddings
+
+        signals: list[tuple[str, str]] = []
+        for desire_id, config in catalog.fixed_desires.items():
+            for signal in config.satisfaction_signals:
+                signals.append((desire_id, signal))
+
+        if not signals:
+            self._fingerprint = fp
+            self._signals = []
+            self._embeddings = []
+            return [], []
+
+        embeddings = embed_fn([sig for _, sig in signals])
+
+        self._fingerprint = fp
+        self._signals = signals
+        self._embeddings = embeddings
+        self._save()
+        return signals, embeddings
+
+    # -- persistence -------------------------------------------------
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            with open(self._path, encoding="utf-8") as f:
+                data = json.load(f)
+            self._fingerprint = data.get("fingerprint", "")
+            self._signals = [(s[0], s[1]) for s in data.get("signals", [])]
+            self._embeddings = data.get("embeddings", [])
+        except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+            logger.warning("Signal embedding cache load failed: %s", exc)
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "fingerprint": self._fingerprint,
+            "signals": [list(s) for s in self._signals],
+            "embeddings": self._embeddings,
+        }
+        with open(self._path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False)
+
+
+def _compute_fingerprint(catalog: DesireCatalog) -> str:
+    """SHA-256 of sorted signal texts.  Deterministic across restarts."""
+    parts: list[str] = []
+    for desire_id, config in sorted(catalog.fixed_desires.items()):
+        for signal in sorted(config.satisfaction_signals):
+            parts.append(f"{desire_id}:{signal}")
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+
 def infer_desire_satisfaction(
     content: str,
     valence: float,
     intensity: float,
     catalog: DesireCatalog,
     embed_fn: Callable[[list[str]], list[list[float]]],
+    signal_cache: SignalEmbeddingCache | None = None,
 ) -> list[tuple[str, float]]:
     """Infer which desires are partially satisfied by a remembered experience.
 
@@ -45,19 +136,25 @@ def infer_desire_satisfaction(
     if valence <= 0.2 or intensity <= 0.3:
         return []
 
-    desire_signals: list[tuple[str, str]] = []
-    for desire_id, config in catalog.fixed_desires.items():
-        for signal in config.satisfaction_signals:
-            desire_signals.append((desire_id, signal))
+    if signal_cache is not None:
+        desire_signals, signal_embeddings = signal_cache.get(catalog, embed_fn)
+        if not desire_signals:
+            return []
+        content_embedding = embed_fn([content])[0]
+    else:
+        desire_signals = []
+        for desire_id, config in catalog.fixed_desires.items():
+            for signal in config.satisfaction_signals:
+                desire_signals.append((desire_id, signal))
 
-    if not desire_signals:
-        return []
+        if not desire_signals:
+            return []
 
-    texts = [content] + [signal for _, signal in desire_signals]
-    embeddings = embed_fn(texts)
+        texts = [content] + [signal for _, signal in desire_signals]
+        embeddings = embed_fn(texts)
 
-    content_embedding = embeddings[0]
-    signal_embeddings = embeddings[1:]
+        content_embedding = embeddings[0]
+        signal_embeddings = embeddings[1:]
 
     best_per_desire: dict[str, float] = {}
     for i, (desire_id, _) in enumerate(desire_signals):

--- a/ego-mcp/src/ego_mcp/server.py
+++ b/ego-mcp/src/ego_mcp/server.py
@@ -21,6 +21,7 @@ from ego_mcp.config import EgoConfig
 from ego_mcp.consolidation import ConsolidationEngine
 from ego_mcp.desire import DesireEngine
 from ego_mcp.desire_catalog import DesireConfigurationError
+from ego_mcp.desire_satisfaction import SignalEmbeddingCache
 from ego_mcp.embedding import EgoEmbeddingFunction, create_embedding_provider
 from ego_mcp.episode import EpisodeStore
 from ego_mcp.impulse import ImpulseManager
@@ -44,6 +45,7 @@ _consolidation: ConsolidationEngine | None = None
 _workspace_sync: WorkspaceMemorySync | None = None
 _notions: NotionStore | None = None
 _impulse: ImpulseManager | None = None
+_signal_cache: SignalEmbeddingCache | None = None
 
 # --- Re-exported handler/helper symbols for compatibility with tests ---
 _REMEMBER_DUPLICATE_PREFIX = _handlers._REMEMBER_DUPLICATE_PREFIX
@@ -444,6 +446,7 @@ async def _dispatch(
             args,
             desire_engine=desire,
             embed_fn=getattr(memory, "_embedding_fn", None),
+            signal_cache=_signal_cache,
         )
         if not result.startswith(_REMEMBER_DUPLICATE_PREFIX):
             _safe_satisfy_implicit("remember", category=args.get("category"))
@@ -487,7 +490,7 @@ async def _dispatch(
 
 def init_server(config: EgoConfig | None = None) -> None:
     """Initialize all dependencies. Called from main() or tests."""
-    global _config, _memory, _desire, _episodes, _consolidation, _workspace_sync, _notions, _impulse
+    global _config, _memory, _desire, _episodes, _consolidation, _workspace_sync, _notions, _impulse, _signal_cache
 
     if config is None:
         config = EgoConfig.from_env()
@@ -507,6 +510,9 @@ def init_server(config: EgoConfig | None = None) -> None:
     _memory.connect()
 
     _desire = DesireEngine.from_data_dir(config.data_dir)
+    _signal_cache = SignalEmbeddingCache(
+        config.data_dir / "cache" / "signal_embeddings.json"
+    )
 
     client = _memory.get_client()
     episodes_collection = client.get_or_create_collection(

--- a/ego-mcp/tests/test_desire_satisfaction.py
+++ b/ego-mcp/tests/test_desire_satisfaction.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import math
+from pathlib import Path
 
 import pytest
 
@@ -13,7 +15,12 @@ from ego_mcp.desire_catalog import (
     FixedDesireConfig,
     default_desire_catalog,
 )
-from ego_mcp.desire_satisfaction import _cosine_similarity, infer_desire_satisfaction
+from ego_mcp.desire_satisfaction import (
+    SignalEmbeddingCache,
+    _compute_fingerprint,
+    _cosine_similarity,
+    infer_desire_satisfaction,
+)
 
 
 def _make_catalog(
@@ -185,3 +192,146 @@ class TestInferDesireSatisfaction:
 
         results = infer_desire_satisfaction("c", 0.5, 0.5, catalog, embed)
         assert isinstance(results, list)
+
+    def test_with_signal_cache_produces_same_results(self, tmp_path: Path) -> None:
+        """Cache path should produce identical results to uncached."""
+        catalog = _make_catalog({"desire_a": ["matching signal"]})
+        cache = SignalEmbeddingCache(tmp_path / "cache.json")
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            return [[1.0, 0.0] for _ in texts]
+
+        uncached = infer_desire_satisfaction("content", 0.5, 0.5, catalog, embed)
+        cached = infer_desire_satisfaction(
+            "content", 0.5, 0.5, catalog, embed, signal_cache=cache
+        )
+        assert cached == uncached
+
+
+class TestSignalEmbeddingCache:
+    def test_disk_persistence(self, tmp_path: Path) -> None:
+        """Embeddings should survive across cache instances."""
+        cache_path = tmp_path / "cache.json"
+        catalog = _make_catalog({"d1": ["sig1"]})
+        call_count = 0
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            nonlocal call_count
+            call_count += 1
+            return [[1.0, 0.0] for _ in texts]
+
+        cache1 = SignalEmbeddingCache(cache_path)
+        signals1, embs1 = cache1.get(catalog, embed)
+        assert call_count == 1
+        assert cache_path.exists()
+
+        # New instance should load from disk, no embed call
+        cache2 = SignalEmbeddingCache(cache_path)
+        signals2, embs2 = cache2.get(catalog, embed)
+        assert call_count == 1  # no additional API call
+        assert signals1 == signals2
+        assert embs1 == embs2
+
+    def test_in_memory_hit(self, tmp_path: Path) -> None:
+        """Repeated calls on same instance should not re-embed."""
+        catalog = _make_catalog({"d1": ["sig1"]})
+        call_count = 0
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            nonlocal call_count
+            call_count += 1
+            return [[1.0, 0.0] for _ in texts]
+
+        cache = SignalEmbeddingCache(tmp_path / "cache.json")
+        cache.get(catalog, embed)
+        cache.get(catalog, embed)
+        cache.get(catalog, embed)
+        assert call_count == 1
+
+    def test_fingerprint_invalidation_on_catalog_change(
+        self, tmp_path: Path
+    ) -> None:
+        """Changing catalog signals should invalidate the cache."""
+        cache_path = tmp_path / "cache.json"
+        catalog_v1 = _make_catalog({"d1": ["signal_a"]})
+        catalog_v2 = _make_catalog({"d1": ["signal_b"]})
+        call_count = 0
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            nonlocal call_count
+            call_count += 1
+            return [[1.0, 0.0] for _ in texts]
+
+        cache = SignalEmbeddingCache(cache_path)
+        cache.get(catalog_v1, embed)
+        assert call_count == 1
+
+        cache.get(catalog_v2, embed)
+        assert call_count == 2  # re-embedded due to fingerprint change
+
+    def test_empty_signals(self, tmp_path: Path) -> None:
+        """Catalog with no signals should return empty without crash."""
+        catalog = _make_catalog({"d1": []})
+        cache = SignalEmbeddingCache(tmp_path / "cache.json")
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            return [[0.0]] * len(texts)
+
+        signals, embs = cache.get(catalog, embed)
+        assert signals == []
+        assert embs == []
+
+    def test_corrupted_cache_file(self, tmp_path: Path) -> None:
+        """Corrupted cache file should be handled gracefully."""
+        cache_path = tmp_path / "cache.json"
+        cache_path.write_text("not valid json", encoding="utf-8")
+
+        catalog = _make_catalog({"d1": ["sig"]})
+        call_count = 0
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            nonlocal call_count
+            call_count += 1
+            return [[1.0, 0.0] for _ in texts]
+
+        cache = SignalEmbeddingCache(cache_path)
+        signals, embs = cache.get(catalog, embed)
+        assert call_count == 1
+        assert len(signals) == 1
+
+    def test_disk_persistence_across_restart(self, tmp_path: Path) -> None:
+        """Verify JSON structure written to disk is valid and complete."""
+        cache_path = tmp_path / "cache.json"
+        catalog = _make_catalog({"d1": ["sig1"], "d2": ["sig2a", "sig2b"]})
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            return [[float(i), 0.0] for i in range(len(texts))]
+
+        cache = SignalEmbeddingCache(cache_path)
+        cache.get(catalog, embed)
+
+        with open(cache_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert "fingerprint" in data
+        assert "signals" in data
+        assert "embeddings" in data
+        assert len(data["signals"]) == 3
+        assert len(data["embeddings"]) == 3
+
+
+class TestComputeFingerprint:
+    def test_deterministic(self) -> None:
+        catalog = _make_catalog({"d1": ["a", "b"], "d2": ["c"]})
+        assert _compute_fingerprint(catalog) == _compute_fingerprint(catalog)
+
+    def test_order_independent(self) -> None:
+        """Fingerprint should be the same regardless of dict insertion order."""
+        cat1 = _make_catalog({"a": ["x", "y"], "b": ["z"]})
+        cat2 = _make_catalog({"b": ["z"], "a": ["y", "x"]})
+        assert _compute_fingerprint(cat1) == _compute_fingerprint(cat2)
+
+    def test_different_signals_different_fingerprint(self) -> None:
+        cat1 = _make_catalog({"d1": ["signal_a"]})
+        cat2 = _make_catalog({"d1": ["signal_b"]})
+        assert _compute_fingerprint(cat1) != _compute_fingerprint(cat2)

--- a/ego-mcp/tests/test_server_surface_memory.py
+++ b/ego-mcp/tests/test_server_surface_memory.py
@@ -266,7 +266,7 @@ class TestHandleRememberDesireSatisfaction:
         monkeypatch.setattr(
             mem_mod,
             "infer_desire_satisfaction",
-            lambda content, valence, intensity, cat, fn: [(target_desire, 0.4)],
+            lambda content, valence, intensity, cat, fn, **kw: [(target_desire, 0.4)],
         )
 
         def fake_embed(texts: list[str]) -> list[list[float]]:
@@ -307,7 +307,7 @@ class TestHandleRememberDesireSatisfaction:
         monkeypatch.setattr(
             mem_mod,
             "infer_desire_satisfaction",
-            lambda content, valence, intensity, cat, fn: [(target_desire, 0.4)],
+            lambda content, valence, intensity, cat, fn, **kw: [(target_desire, 0.4)],
         )
 
         def fake_embed(texts: list[str]) -> list[list[float]]:
@@ -341,7 +341,7 @@ class TestHandleRememberDesireSatisfaction:
         monkeypatch.setattr(
             mem_mod,
             "infer_desire_satisfaction",
-            lambda content, valence, intensity, cat, fn: [],
+            lambda content, valence, intensity, cat, fn, **kw: [],
         )
 
         def fake_embed(texts: list[str]) -> list[list[float]]:


### PR DESCRIPTION
## Summary

- `SignalEmbeddingCache` クラスを `desire_satisfaction.py` に追加し、シグナルの embedding を `data_dir/cache/signal_embeddings.json` に永続化
- SHA-256 フィンガープリントでカタログ変更（`configure_desires` 経由・`desires.json` 直接編集の両方）を自動検知・キャッシュ無効化
- キャッシュヒット時の embedding API コールを 26 テキスト → 1 テキスト（コンテンツのみ）に削減
- `infer_desire_satisfaction` の `signal_cache` 引数はオプション（デフォルト `None`）で後方互換を維持

## Test plan

- [ ] `TestSignalEmbeddingCache`: ディスク永続化・インメモリヒット・フィンガープリント無効化・破損ファイル耐性
- [ ] `TestComputeFingerprint`: 決定性・順序非依存・変更検知
- [ ] `TestInferDesireSatisfaction::test_with_signal_cache_produces_same_results`: キャッシュあり/なしで結果が一致
- [ ] 既存の 739 テストが全て通過

```bash
cd ego-mcp
GEMINI_API_KEY=test-key uv run pytest tests -v
uv run isort --check-only src tests
uv run ruff check src tests
uv run mypy src tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)