### PR TITLE
Reject XML-shaped tool arguments with a self-correcting error

### DIFF
--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -1,0 +1,254 @@
+"""Pre-dispatch validation for tool arguments.
+
+LLMs occasionally call MCP tools with parameters wrapped in XML tags
+(e.g. ``{"content": "<content>hello</content>"}``) instead of plain JSON
+values. This module detects that specific failure mode and produces a
+structured error message the model can act on in its next turn.
+
+The validator is intentionally narrow: it only rejects clearly XML-shaped
+strings. General JSON Schema type checking is out of scope.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from mcp.types import Tool
+
+from ego_mcp._server_tools import BACKEND_TOOLS, SURFACE_TOOLS
+
+_EXCERPT_LIMIT = 120
+_ERROR_MARKER = "[parameter_format_error]"
+
+
+class ToolParameterFormatError(Exception):
+    """Raised when tool arguments are formatted in an unsupported shape.
+
+    The string form of the exception is the full LLM-facing message,
+    intended to be returned as tool output so the model can self-correct.
+    """
+
+
+def _build_tool_schema_index() -> dict[str, Tool]:
+    index: dict[str, Tool] = {}
+    for tool in (*SURFACE_TOOLS, *BACKEND_TOOLS):
+        index[tool.name] = tool
+    return index
+
+
+_TOOL_INDEX: dict[str, Tool] = _build_tool_schema_index()
+
+_ANY_TAG_RE = re.compile(r"<([A-Za-z_][A-Za-z0-9_]*)\s*(/?)>")
+_WHOLE_WRAPPED_RE = re.compile(
+    r"^\s*<([A-Za-z_][A-Za-z0-9_]*)\s*>.*</\1\s*>\s*$",
+    re.DOTALL,
+)
+
+
+def _matches_named_tag(value: str, tag: str) -> bool:
+    """Detect ``<tag>...</tag>`` or ``<tag/>`` for an exact tag name."""
+    pattern = rf"<{re.escape(tag)}\s*(?:/>|>.*?</{re.escape(tag)}>)"
+    return re.search(pattern, value, flags=re.DOTALL) is not None
+
+
+def _looks_like_xml_blob(value: str) -> bool:
+    """Heuristic: the value is a multi-tag XML blob, not prose.
+
+    Requires at least two distinct tag-like opens whose names are all
+    alphanumeric/underscore. This avoids false-positives on natural
+    sentences like ``"a < b < c"``.
+    """
+    matches = _ANY_TAG_RE.findall(value)
+    if len(matches) < 2:
+        return False
+    return all(bool(name) for name, _ in matches)
+
+
+def _is_wholly_wrapped_in_tag(value: str) -> bool:
+    """The entire string is ``<tag>...</tag>`` — clear XML misuse."""
+    return _WHOLE_WRAPPED_RE.match(value) is not None
+
+
+def _excerpt(value: str) -> str:
+    collapsed = " ".join(value.split())
+    if len(collapsed) <= _EXCERPT_LIMIT:
+        return collapsed
+    return collapsed[:_EXCERPT_LIMIT] + "..."
+
+
+def _describe_type(schema: dict[str, Any]) -> str:
+    if "enum" in schema and isinstance(schema["enum"], list):
+        return "one of " + " | ".join(repr(v) for v in schema["enum"])
+    if "oneOf" in schema:
+        return "string or array of strings"
+    t = schema.get("type")
+    if t == "array":
+        item_t = schema.get("items", {}).get("type", "any")
+        return f"array of {item_t}"
+    if isinstance(t, str):
+        return t
+    return "any"
+
+
+def _render_expected_shape(tool: Tool) -> str:
+    input_schema = tool.inputSchema or {}
+    properties: dict[str, Any] = input_schema.get("properties", {}) or {}
+    required = set(input_schema.get("required", []) or [])
+
+    if not properties:
+        return "  {}   # no parameters"
+
+    lines = ["  {"]
+    items = list(properties.items())
+    for idx, (name, prop_schema) in enumerate(items):
+        type_desc = _describe_type(prop_schema or {})
+        qualifier = "required" if name in required else "optional"
+        comma = "," if idx < len(items) - 1 else ""
+        lines.append(f'    "{name}": <{type_desc}, {qualifier}>{comma}')
+    lines.append("  }")
+    return "\n".join(lines)
+
+
+def _partition_params(tool: Tool) -> tuple[list[str], list[str]]:
+    input_schema = tool.inputSchema or {}
+    properties: dict[str, Any] = input_schema.get("properties", {}) or {}
+    required = set(input_schema.get("required", []) or [])
+    required_list = [n for n in properties if n in required]
+    optional_list = [n for n in properties if n not in required]
+    return required_list, optional_list
+
+
+def _example_call(tool: Tool) -> str:
+    input_schema = tool.inputSchema or {}
+    properties: dict[str, Any] = input_schema.get("properties", {}) or {}
+    required = input_schema.get("required", []) or []
+
+    fields: list[str] = []
+    for name in required:
+        prop = properties.get(name, {}) or {}
+        fields.append(f'"{name}": {_example_value(prop)}')
+
+    if not fields and properties:
+        first_name, first_prop = next(iter(properties.items()))
+        fields.append(f'"{first_name}": {_example_value(first_prop)}')
+
+    if not fields:
+        return "  {}"
+    return "  {" + ", ".join(fields) + "}"
+
+
+def _example_value(prop_schema: dict[str, Any]) -> str:
+    if "enum" in prop_schema and isinstance(prop_schema["enum"], list) and prop_schema["enum"]:
+        return repr(prop_schema["enum"][0])
+    t = prop_schema.get("type")
+    if t == "string":
+        return '"..."'
+    if t == "integer":
+        return "1"
+    if t == "number":
+        return "0.5"
+    if t == "boolean":
+        return "false"
+    if t == "array":
+        item_t = prop_schema.get("items", {}).get("type")
+        if item_t == "string":
+            return '["..."]'
+        return "[]"
+    if t == "object":
+        return "{}"
+    return '"..."'
+
+
+def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return a list of ``(param_name, excerpt)`` tuples for XML-shaped values.
+
+    ``param_name`` is the dict key whose value looks like XML. The excerpt
+    is a truncated view of the offending string.
+    """
+    tool = _TOOL_INDEX.get(tool_name)
+    known_params: set[str] = set()
+    if tool is not None:
+        known_params = set((tool.inputSchema or {}).get("properties", {}).keys())
+
+    offenders: list[tuple[str, str]] = []
+
+    def _scan(key: str, value: Any) -> None:
+        if isinstance(value, str):
+            for param in known_params:
+                if _matches_named_tag(value, param):
+                    offenders.append((key, _excerpt(value)))
+                    return
+            if _looks_like_xml_blob(value) or _is_wholly_wrapped_in_tag(value):
+                offenders.append((key, _excerpt(value)))
+                return
+        elif isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                _scan(f"{key}.{sub_key}", sub_value)
+        elif isinstance(value, list):
+            for idx, item in enumerate(value):
+                _scan(f"{key}[{idx}]", item)
+
+    for key, value in args.items():
+        _scan(key, value)
+
+    return offenders
+
+
+def _format_correction_message(
+    tool_name: str,
+    offenders: list[tuple[str, str]],
+    tool: Tool,
+) -> str:
+    offender_lines: list[str] = []
+    for name, excerpt in offenders:
+        offender_lines.append(f"  - `{name}`: {excerpt!r}")
+
+    required_list, optional_list = _partition_params(tool)
+    required_str = ", ".join(required_list) if required_list else "(none)"
+    optional_str = ", ".join(optional_list) if optional_list else "(none)"
+
+    return "\n".join(
+        [
+            f"{_ERROR_MARKER} Tool `{tool_name}` expects JSON arguments, not XML.",
+            "",
+            "Offending parameter(s) (value contains XML-style tags):",
+            *offender_lines,
+            "",
+            "Do NOT wrap values in XML tags. Pass a JSON object whose keys are",
+            "the parameter names and whose values are the raw values.",
+            "",
+            f"Expected JSON shape for `{tool_name}`:",
+            _render_expected_shape(tool),
+            "",
+            f"Required: {required_str}",
+            f"Optional: {optional_str}",
+            "",
+            "Example of a correct call:",
+            _example_call(tool),
+            "",
+            "Please retry this tool call with plain JSON arguments "
+            "(no `<tag>` wrappers).",
+        ]
+    )
+
+
+def validate_tool_arguments(tool_name: str, args: dict[str, Any] | None) -> None:
+    """Raise :class:`ToolParameterFormatError` when args look XML-shaped.
+
+    Unknown tool names pass through silently; ``_dispatch`` already has a
+    fallback path for them.
+    """
+    if not args:
+        return
+    tool = _TOOL_INDEX.get(tool_name)
+    if tool is None:
+        return
+
+    offenders = _find_offenders(tool_name, args)
+    if not offenders:
+        return
+
+    raise ToolParameterFormatError(
+        _format_correction_message(tool_name, offenders, tool)
+    )

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -42,8 +42,20 @@ _TOOL_INDEX: dict[str, Tool] = _build_tool_schema_index()
 
 
 def _matches_named_tag(value: str, tag: str) -> bool:
-    """Detect ``<tag>...</tag>`` or ``<tag/>`` for an exact tag name."""
-    pattern = rf"<{re.escape(tag)}\s*(?:/>|>.*?</{re.escape(tag)}>)"
+    """Detect ``<tag>...</tag>`` or ``<tag/>`` for an exact tag name.
+
+    Allows optional attributes on the opening tag so wrappers like
+    ``<content type="text">hello</content>`` are still flagged. The
+    attribute span is anchored to a leading whitespace character so
+    sibling tag names (``<contentx>``) don't accidentally match.
+    """
+    escaped = re.escape(tag)
+    pattern = (
+        rf"<{escaped}"
+        rf"(?:\s[^>]*?)?"  # optional attributes (must start with whitespace)
+        rf"\s*"
+        rf"(?:/>|>.*?</{escaped}\s*>)"
+    )
     return re.search(pattern, value, flags=re.DOTALL) is not None
 
 

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -19,7 +19,6 @@ from mcp.types import Tool
 
 from ego_mcp._server_tools import BACKEND_TOOLS, SURFACE_TOOLS
 
-_EXCERPT_LIMIT = 120
 _ERROR_MARKER = "[parameter_format_error]"
 
 
@@ -42,12 +41,15 @@ _TOOL_INDEX: dict[str, Tool] = _build_tool_schema_index()
 
 
 def _matches_named_tag(value: str, tag: str) -> bool:
-    """Detect ``<tag>...</tag>`` or ``<tag/>`` for an exact tag name.
+    """Return ``True`` if ``value`` is *wholly* an XML wrapper for ``tag``.
 
-    Allows optional attributes on the opening tag so wrappers like
-    ``<content type="text">hello</content>`` are still flagged. The
-    attribute span is anchored to a leading whitespace character so
-    sibling tag names (``<contentx>``) don't accidentally match.
+    The match is anchored: after stripping surrounding whitespace the
+    entire value must be ``<tag>...</tag>`` or ``<tag/>`` (optionally
+    with attributes). A wrapper embedded inside longer free text —
+    e.g. ``"see <content>foo</content> for an example"`` — is
+    legitimate prose and must not be flagged. Attribute spans are
+    anchored to a leading whitespace so sibling names like
+    ``<contentx>`` don't collapse onto ``<content>``.
     """
     escaped = re.escape(tag)
     pattern = (
@@ -56,14 +58,7 @@ def _matches_named_tag(value: str, tag: str) -> bool:
         rf"\s*"
         rf"(?:/>|>.*?</{escaped}\s*>)"
     )
-    return re.search(pattern, value, flags=re.DOTALL) is not None
-
-
-def _excerpt(value: str) -> str:
-    collapsed = " ".join(value.split())
-    if len(collapsed) <= _EXCERPT_LIMIT:
-        return collapsed
-    return collapsed[:_EXCERPT_LIMIT] + "..."
+    return re.fullmatch(pattern, value.strip(), flags=re.DOTALL) is not None
 
 
 def _describe_type(schema: dict[str, Any]) -> str:
@@ -158,42 +153,41 @@ def _example_value(prop_schema: dict[str, Any]) -> str:
     return '"..."'
 
 
-def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str]]:
-    """Return a list of ``(param_name, excerpt)`` tuples for XML-shaped values.
+def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[str]:
+    """Return the names of top-level args whose value is an XML wrapper.
 
     Detection is intentionally limited to **top-level string arguments**:
     a value is flagged only when it's a string at the top level of
-    ``args`` and contains ``<key>...</key>`` (or ``<key/>``) for its own
-    key. Nested dicts and array items are not recursed into — free-form
-    parameters such as ``update_self.value`` or ``remember.body_state``
-    can carry arbitrary user payloads where same-named tags are
-    legitimate data, and there is no reliable way to tell apart "the LLM
-    wrapped a parameter in XML" from "the user really wants to store
-    this XML-looking string" without a strict schema for the nested
-    shape. The top-level check covers the dominant LLM failure mode.
+    ``args`` and is wholly ``<key>...</key>`` (or ``<key/>``) for its
+    own key. Nested dicts and array items are not recursed into —
+    free-form parameters such as ``update_self.value`` or
+    ``remember.body_state`` can carry arbitrary user payloads where
+    same-named tags are legitimate data, and there is no reliable way
+    to tell "the LLM wrapped a parameter in XML" apart from "the user
+    really wants to store this XML-looking string" without a strict
+    schema for the nested shape. The top-level check covers the
+    dominant LLM failure mode.
     """
     if _TOOL_INDEX.get(tool_name) is None:
         return []
 
-    offenders: list[tuple[str, str]] = []
+    offenders: list[str] = []
     for key, value in args.items():
         if isinstance(value, str) and _matches_named_tag(value, key):
-            offenders.append((key, _excerpt(value)))
+            offenders.append(key)
     return offenders
 
 
 def _format_correction_message(
     tool_name: str,
-    offenders: list[tuple[str, str]],
+    offenders: list[str],
     tool: Tool,
 ) -> str:
-    offender_lines: list[str] = []
-    for name, excerpt in offenders:
-        # `json.dumps` keeps the message in the same JSON-style quoting
-        # convention as the example block, and preserves non-ASCII
-        # characters readably (`ensure_ascii=False`).
-        quoted = json.dumps(excerpt, ensure_ascii=False)
-        offender_lines.append(f"  - `{name}`: {quoted}")
+    # Only report parameter *names*, never the offending value content.
+    # The correction string is returned as tool output and may be
+    # persisted in logs, so echoing the value would leak payloads for
+    # tools like `remember` that accept `private=true` memories.
+    offender_lines = [f"  - `{name}`" for name in offenders]
 
     required_list, optional_list = _partition_params(tool)
     required_str = ", ".join(required_list) if required_list else "(none)"
@@ -203,7 +197,7 @@ def _format_correction_message(
         [
             f"{_ERROR_MARKER} Tool `{tool_name}` expects JSON arguments, not XML.",
             "",
-            "Offending parameter(s) (value contains XML-style tags):",
+            "Offending parameter(s) (value is wrapped in a same-named XML tag):",
             *offender_lines,
             "",
             "Do NOT wrap values in XML tags. Pass a JSON object whose keys are",

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -11,6 +11,7 @@ strings. General JSON Schema type checking is out of scope.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -55,7 +56,7 @@ def _excerpt(value: str) -> str:
 
 def _describe_type(schema: dict[str, Any]) -> str:
     if "enum" in schema and isinstance(schema["enum"], list):
-        return "one of " + " | ".join(repr(v) for v in schema["enum"])
+        return "one of " + " | ".join(json.dumps(v) for v in schema["enum"])
     if "oneOf" in schema:
         return "string or array of strings"
     t = schema.get("type")
@@ -116,7 +117,7 @@ def _example_call(tool: Tool) -> str:
 
 def _example_value(prop_schema: dict[str, Any]) -> str:
     if "enum" in prop_schema and isinstance(prop_schema["enum"], list) and prop_schema["enum"]:
-        return repr(prop_schema["enum"][0])
+        return json.dumps(prop_schema["enum"][0])
     t = prop_schema.get("type")
     if t == "string":
         return '"..."'

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -57,8 +57,17 @@ def _excerpt(value: str) -> str:
 def _describe_type(schema: dict[str, Any]) -> str:
     if "enum" in schema and isinstance(schema["enum"], list):
         return "one of " + " | ".join(json.dumps(v) for v in schema["enum"])
-    if "oneOf" in schema:
-        return "string or array of strings"
+    if "oneOf" in schema and isinstance(schema["oneOf"], list):
+        # De-duplicate while preserving order so e.g.
+        # `oneOf: [string, array<string>]` reads cleanly.
+        seen: set[str] = set()
+        unique: list[str] = []
+        for variant in schema["oneOf"]:
+            described = _describe_type(variant or {})
+            if described not in seen:
+                seen.add(described)
+                unique.append(described)
+        return " or ".join(unique) if unique else "any"
     t = schema.get("type")
     if t == "array":
         item_t = schema.get("items", {}).get("type", "any")
@@ -140,36 +149,24 @@ def _example_value(prop_schema: dict[str, Any]) -> str:
 def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str]]:
     """Return a list of ``(param_name, excerpt)`` tuples for XML-shaped values.
 
-    Detection is deliberately narrow: a value is flagged only when it
-    contains an XML tag whose name matches **the argument's own key**
-    (or, for items inside an array, the array's key). That is the
-    single unambiguous wrapper-misuse signal — e.g. ``content`` →
-    ``"<content>...</content>"``. Values that merely *mention* tags
-    whose names happen to collide with *other* tool parameters
-    (``remember.content = "<emotion>joy</emotion>"``) are treated as
-    legitimate user content and accepted.
+    Detection is intentionally limited to **top-level string arguments**:
+    a value is flagged only when it's a string at the top level of
+    ``args`` and contains ``<key>...</key>`` (or ``<key/>``) for its own
+    key. Nested dicts and array items are not recursed into — free-form
+    parameters such as ``update_self.value`` or ``remember.body_state``
+    can carry arbitrary user payloads where same-named tags are
+    legitimate data, and there is no reliable way to tell apart "the LLM
+    wrapped a parameter in XML" from "the user really wants to store
+    this XML-looking string" without a strict schema for the nested
+    shape. The top-level check covers the dominant LLM failure mode.
     """
     if _TOOL_INDEX.get(tool_name) is None:
         return []
 
     offenders: list[tuple[str, str]] = []
-
-    def _scan(key: str, value: Any, tag: str) -> None:
-        if isinstance(value, str):
-            if _matches_named_tag(value, tag):
-                offenders.append((key, _excerpt(value)))
-        elif isinstance(value, dict):
-            # Each nested entry is checked against its own key name only.
-            for sub_key, sub_value in value.items():
-                _scan(f"{key}.{sub_key}", sub_value, sub_key)
-        elif isinstance(value, list):
-            # Array items inherit the array's key as their tag candidate.
-            for idx, item in enumerate(value):
-                _scan(f"{key}[{idx}]", item, tag)
-
     for key, value in args.items():
-        _scan(key, value, key)
-
+        if isinstance(value, str) and _matches_named_tag(value, key):
+            offenders.append((key, _excerpt(value)))
     return offenders
 
 
@@ -180,7 +177,11 @@ def _format_correction_message(
 ) -> str:
     offender_lines: list[str] = []
     for name, excerpt in offenders:
-        offender_lines.append(f"  - `{name}`: {excerpt!r}")
+        # `json.dumps` keeps the message in the same JSON-style quoting
+        # convention as the example block, and preserves non-ASCII
+        # characters readably (`ensure_ascii=False`).
+        quoted = json.dumps(excerpt, ensure_ascii=False)
+        offender_lines.append(f"  - `{name}`: {quoted}")
 
     required_list, optional_list = _partition_params(tool)
     required_str = ", ".join(required_list) if required_list else "(none)"

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -141,42 +141,34 @@ def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str
     """Return a list of ``(param_name, excerpt)`` tuples for XML-shaped values.
 
     Detection is deliberately narrow: a value is flagged only when it
-    contains an XML tag whose name is **also a parameter name of this
-    tool, or a key of the enclosing dict**. That combination is the
-    specific wrapper misuse we want to catch (e.g. ``content`` →
-    ``"<content>...</content>"``). Free-form text that merely *mentions*
-    HTML/XML (``"Use <div> and <span>"``) or stores an intentional XML
-    snippet (``"<note>memo</note>"``) is left alone.
+    contains an XML tag whose name matches **the argument's own key**
+    (or, for items inside an array, the array's key). That is the
+    single unambiguous wrapper-misuse signal — e.g. ``content`` →
+    ``"<content>...</content>"``. Values that merely *mention* tags
+    whose names happen to collide with *other* tool parameters
+    (``remember.content = "<emotion>joy</emotion>"``) are treated as
+    legitimate user content and accepted.
     """
-    tool = _TOOL_INDEX.get(tool_name)
-    known_params: set[str] = set()
-    if tool is not None:
-        known_params = set((tool.inputSchema or {}).get("properties", {}).keys())
+    if _TOOL_INDEX.get(tool_name) is None:
+        return []
 
     offenders: list[tuple[str, str]] = []
 
-    def _scan(key: str, value: Any, tag_candidates: set[str]) -> None:
+    def _scan(key: str, value: Any, tag: str) -> None:
         if isinstance(value, str):
-            for tag in tag_candidates:
-                if _matches_named_tag(value, tag):
-                    offenders.append((key, _excerpt(value)))
-                    return
+            if _matches_named_tag(value, tag):
+                offenders.append((key, _excerpt(value)))
         elif isinstance(value, dict):
-            # Allow the nested dict's own keys to act as tag candidates:
-            # ``body_state.time_phase = "<time_phase>..."`` is a clear
-            # misuse even though ``time_phase`` isn't a top-level param.
+            # Each nested entry is checked against its own key name only.
             for sub_key, sub_value in value.items():
-                _scan(
-                    f"{key}.{sub_key}",
-                    sub_value,
-                    tag_candidates | {sub_key},
-                )
+                _scan(f"{key}.{sub_key}", sub_value, sub_key)
         elif isinstance(value, list):
+            # Array items inherit the array's key as their tag candidate.
             for idx, item in enumerate(value):
-                _scan(f"{key}[{idx}]", item, tag_candidates)
+                _scan(f"{key}[{idx}]", item, tag)
 
     for key, value in args.items():
-        _scan(key, value, known_params)
+        _scan(key, value, key)
 
     return offenders
 

--- a/ego-mcp/src/ego_mcp/_server_param_validation.py
+++ b/ego-mcp/src/ego_mcp/_server_param_validation.py
@@ -39,35 +39,11 @@ def _build_tool_schema_index() -> dict[str, Tool]:
 
 _TOOL_INDEX: dict[str, Tool] = _build_tool_schema_index()
 
-_ANY_TAG_RE = re.compile(r"<([A-Za-z_][A-Za-z0-9_]*)\s*(/?)>")
-_WHOLE_WRAPPED_RE = re.compile(
-    r"^\s*<([A-Za-z_][A-Za-z0-9_]*)\s*>.*</\1\s*>\s*$",
-    re.DOTALL,
-)
-
 
 def _matches_named_tag(value: str, tag: str) -> bool:
     """Detect ``<tag>...</tag>`` or ``<tag/>`` for an exact tag name."""
     pattern = rf"<{re.escape(tag)}\s*(?:/>|>.*?</{re.escape(tag)}>)"
     return re.search(pattern, value, flags=re.DOTALL) is not None
-
-
-def _looks_like_xml_blob(value: str) -> bool:
-    """Heuristic: the value is a multi-tag XML blob, not prose.
-
-    Requires at least two distinct tag-like opens whose names are all
-    alphanumeric/underscore. This avoids false-positives on natural
-    sentences like ``"a < b < c"``.
-    """
-    matches = _ANY_TAG_RE.findall(value)
-    if len(matches) < 2:
-        return False
-    return all(bool(name) for name, _ in matches)
-
-
-def _is_wholly_wrapped_in_tag(value: str) -> bool:
-    """The entire string is ``<tag>...</tag>`` — clear XML misuse."""
-    return _WHOLE_WRAPPED_RE.match(value) is not None
 
 
 def _excerpt(value: str) -> str:
@@ -163,8 +139,13 @@ def _example_value(prop_schema: dict[str, Any]) -> str:
 def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str]]:
     """Return a list of ``(param_name, excerpt)`` tuples for XML-shaped values.
 
-    ``param_name`` is the dict key whose value looks like XML. The excerpt
-    is a truncated view of the offending string.
+    Detection is deliberately narrow: a value is flagged only when it
+    contains an XML tag whose name is **also a parameter name of this
+    tool, or a key of the enclosing dict**. That combination is the
+    specific wrapper misuse we want to catch (e.g. ``content`` →
+    ``"<content>...</content>"``). Free-form text that merely *mentions*
+    HTML/XML (``"Use <div> and <span>"``) or stores an intentional XML
+    snippet (``"<note>memo</note>"``) is left alone.
     """
     tool = _TOOL_INDEX.get(tool_name)
     known_params: set[str] = set()
@@ -173,24 +154,28 @@ def _find_offenders(tool_name: str, args: dict[str, Any]) -> list[tuple[str, str
 
     offenders: list[tuple[str, str]] = []
 
-    def _scan(key: str, value: Any) -> None:
+    def _scan(key: str, value: Any, tag_candidates: set[str]) -> None:
         if isinstance(value, str):
-            for param in known_params:
-                if _matches_named_tag(value, param):
+            for tag in tag_candidates:
+                if _matches_named_tag(value, tag):
                     offenders.append((key, _excerpt(value)))
                     return
-            if _looks_like_xml_blob(value) or _is_wholly_wrapped_in_tag(value):
-                offenders.append((key, _excerpt(value)))
-                return
         elif isinstance(value, dict):
+            # Allow the nested dict's own keys to act as tag candidates:
+            # ``body_state.time_phase = "<time_phase>..."`` is a clear
+            # misuse even though ``time_phase`` isn't a top-level param.
             for sub_key, sub_value in value.items():
-                _scan(f"{key}.{sub_key}", sub_value)
+                _scan(
+                    f"{key}.{sub_key}",
+                    sub_value,
+                    tag_candidates | {sub_key},
+                )
         elif isinstance(value, list):
             for idx, item in enumerate(value):
-                _scan(f"{key}[{idx}]", item)
+                _scan(f"{key}[{idx}]", item, tag_candidates)
 
     for key, value in args.items():
-        _scan(key, value)
+        _scan(key, value, known_params)
 
     return offenders
 

--- a/ego-mcp/src/ego_mcp/server.py
+++ b/ego-mcp/src/ego_mcp/server.py
@@ -14,6 +14,10 @@ import ego_mcp._server_handlers as _handlers
 from ego_mcp._server_backend_handlers import (
     pop_tool_context as pop_backend_tool_context,
 )
+from ego_mcp._server_param_validation import (
+    ToolParameterFormatError,
+    validate_tool_arguments,
+)
 from ego_mcp._server_runtime import get_tool_metadata, reset_tool_metadata
 from ego_mcp._server_surface_memory import pop_tool_context as pop_memory_tool_context
 from ego_mcp._server_tools import BACKEND_TOOLS, SURFACE_TOOLS
@@ -402,6 +406,19 @@ async def _dispatch(
     """Route tool call to handler."""
     safe_args = _sanitize_tool_args_for_logging(name, args)
     logger.debug("Routing tool call", extra={"tool_name": name, "tool_args": safe_args})
+
+    try:
+        validate_tool_arguments(name, args)
+    except ToolParameterFormatError as exc:
+        logger.warning(
+            "Rejected tool call with XML-formatted parameters",
+            extra={
+                "tool_name": name,
+                "tool_args": safe_args,
+                **_tool_log_context(),
+            },
+        )
+        return str(exc)
 
     if name in {"wake_up", "attune", "introspect"}:
         desire.require_valid_catalog()

--- a/ego-mcp/tests/test_server.py
+++ b/ego-mcp/tests/test_server.py
@@ -1601,3 +1601,39 @@ class TestForgetToolServerHandlers:
         assert "Episode: ep_1" in text
         assert "Memories: 1" in text
         assert "Note: 1 memory(ies) no longer exist." in text
+
+
+class TestParameterFormatValidation:
+    @pytest.mark.asyncio
+    async def test_call_tool_returns_error_text_for_xml_arguments(
+        self,
+        desire: DesireEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        before = _seed_high_desire(desire, "expression")
+
+        handler_calls: list[dict[str, object]] = []
+
+        async def spy_handle_remember(
+            _config: object,
+            _memory: object,
+            args: dict[str, object],
+            **_kwargs: object,
+        ) -> str:
+            handler_calls.append(args)
+            return "should not be reached"
+
+        monkeypatch.setattr(server_mod, "_handle_remember", spy_handle_remember)
+
+        result = await server_mod.call_tool(
+            "remember",
+            {"content": "<content>hello</content>"},
+        )
+
+        assert isinstance(result[0], TextContent)
+        assert "[parameter_format_error]" in result[0].text
+        assert "`remember`" in result[0].text
+        assert "`content`" in result[0].text
+        # Downstream handler must not be invoked and desire must not shift.
+        assert handler_calls == []
+        assert desire.compute_levels()["expression"] == pytest.approx(before)

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -1,0 +1,140 @@
+"""Tests for the pre-dispatch XML-in-arguments validator."""
+
+from __future__ import annotations
+
+import pytest
+
+from ego_mcp._server_param_validation import (
+    ToolParameterFormatError,
+    validate_tool_arguments,
+)
+
+
+class TestValidateToolArguments:
+    def test_rejects_named_tag_wrapping_value(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember", {"content": "<content>hello</content>"}
+            )
+        message = str(exc_info.value)
+        assert "[parameter_format_error]" in message
+        assert "`remember`" in message
+        assert "`content`" in message
+        assert "Required: content" in message
+        assert "<tag>" in message  # correction hint mentions tags
+        assert "Example of a correct call" in message
+
+    def test_rejects_self_closing_named_tag(self) -> None:
+        with pytest.raises(ToolParameterFormatError):
+            validate_tool_arguments("forget", {"memory_id": "<memory_id/>"})
+
+    def test_rejects_multiple_xml_tags_even_when_names_unknown(self) -> None:
+        # `forget` only knows `memory_id`; but multi-tag XML blob is still
+        # a clear XML misuse.
+        with pytest.raises(ToolParameterFormatError):
+            validate_tool_arguments(
+                "forget", {"memory_id": "<id>42</id><type>x</type>"}
+            )
+
+    def test_rejects_xml_wrapping_numeric_parameter(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember",
+                {
+                    "content": "plain content",
+                    "importance": "<importance>3</importance>",
+                },
+            )
+        message = str(exc_info.value)
+        assert "`importance`" in message
+
+    def test_reports_multiple_offenders(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "recall",
+                {
+                    "context": "<context>find me</context>",
+                    "emotion_filter": "<emotion_filter>joy</emotion_filter>",
+                },
+            )
+        message = str(exc_info.value)
+        assert "`context`" in message
+        assert "`emotion_filter`" in message
+
+    def test_detects_xml_inside_array_values(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember",
+                {
+                    "content": "plain content",
+                    "tags": ["<tags>foo</tags>", "<tags>bar</tags>"],
+                },
+            )
+        message = str(exc_info.value)
+        assert "tags[0]" in message or "tags[1]" in message
+
+    def test_detects_xml_inside_nested_dict(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember",
+                {
+                    "content": "plain",
+                    "body_state": {"time_phase": "<time_phase>morning</time_phase>"},
+                },
+            )
+        assert "body_state.time_phase" in str(exc_info.value)
+
+    def test_plain_text_content_is_allowed(self) -> None:
+        validate_tool_arguments(
+            "remember", {"content": "普通の文章です", "emotion": "calm"}
+        )
+
+    def test_natural_angle_brackets_do_not_false_positive(self) -> None:
+        # Prose with `<` characters must not trip the validator.
+        validate_tool_arguments(
+            "remember", {"content": "a < b < c and 3 > 2, but not <3"}
+        )
+
+    def test_valid_consider_them_passes(self) -> None:
+        validate_tool_arguments("consider_them", {"person": "Alice"})
+
+    def test_empty_args_passes(self) -> None:
+        validate_tool_arguments("wake_up", {})
+        validate_tool_arguments("wake_up", None)
+
+    def test_unknown_tool_passes_through(self) -> None:
+        # The dispatcher handles unknown names; validation must not block.
+        validate_tool_arguments(
+            "does_not_exist", {"anything": "<content>x</content>"}
+        )
+
+    def test_error_message_lists_required_and_optional(self) -> None:
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember", {"content": "<content>x</content>"}
+            )
+        message = str(exc_info.value)
+        assert "Required: content" in message
+        # A few optional fields should appear in the listing
+        for optional in ("emotion", "importance", "category"):
+            assert optional in message
+
+    def test_excerpt_is_truncated(self) -> None:
+        long_value = "<content>" + ("x" * 500) + "</content>"
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments("remember", {"content": long_value})
+        message = str(exc_info.value)
+        assert "..." in message
+        # Excerpt shouldn't dump the entire payload
+        assert message.count("x") < 200
+
+    def test_configure_desires_enum_rendered_in_expected_shape(self) -> None:
+        # When the schema has `enum`, the expected-shape section should
+        # surface the allowed values rather than a bare type.
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "configure_desires", {"action": "<action>check</action>"}
+            )
+        message = str(exc_info.value)
+        assert "'check'" in message
+        assert "'set_sentence'" in message

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -53,28 +53,36 @@ class TestValidateToolArguments:
         assert "`context`" in message
         assert "`emotion_filter`" in message
 
-    def test_detects_xml_inside_array_values(self) -> None:
-        with pytest.raises(ToolParameterFormatError) as exc_info:
-            validate_tool_arguments(
-                "remember",
-                {
-                    "content": "plain content",
-                    "tags": ["<tags>foo</tags>", "<tags>bar</tags>"],
+    def test_allows_xml_inside_nested_free_form_dict(self) -> None:
+        # `update_self.value` / `update_relationship.value` are declared
+        # as `{}` (any) in the tool schema — they carry arbitrary user
+        # payload. Same-named tags inside a nested dict are legitimate
+        # data, not wrapper misuse, and must not be rejected.
+        validate_tool_arguments(
+            "update_self",
+            {"field": "notes", "value": {"note": "<note>remember this</note>"}},
+        )
+        validate_tool_arguments(
+            "remember",
+            {
+                "content": "plain",
+                "body_state": {
+                    "time_phase": "<time_phase>morning</time_phase>"
                 },
-            )
-        message = str(exc_info.value)
-        assert "tags[0]" in message or "tags[1]" in message
+            },
+        )
 
-    def test_detects_xml_inside_nested_dict(self) -> None:
-        with pytest.raises(ToolParameterFormatError) as exc_info:
-            validate_tool_arguments(
-                "remember",
-                {
-                    "content": "plain",
-                    "body_state": {"time_phase": "<time_phase>morning</time_phase>"},
-                },
-            )
-        assert "body_state.time_phase" in str(exc_info.value)
+    def test_allows_xml_inside_array_items(self) -> None:
+        # Array items are treated as user content; a string element that
+        # happens to look like `<tags>...</tags>` is not a reliable
+        # wrapper-misuse signal and must pass.
+        validate_tool_arguments(
+            "remember",
+            {
+                "content": "plain content",
+                "tags": ["<tags>foo</tags>", "<tags>bar</tags>"],
+            },
+        )
 
     def test_plain_text_content_is_allowed(self) -> None:
         validate_tool_arguments(
@@ -184,3 +192,31 @@ class TestValidateToolArguments:
         assert match is not None, message
         parsed = _json.loads(match.group(1).strip())
         assert parsed["action"] == "list"
+
+    def test_oneof_type_description_lists_variants(self) -> None:
+        # `remember.shared_with` uses `oneOf: [string, array<string>]`.
+        # The description should derive that from the schema, not be a
+        # hardcoded literal — so future schema edits stay accurate.
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember",
+                {
+                    "content": "<content>x</content>",
+                    "shared_with": "Master",
+                },
+            )
+        message = str(exc_info.value)
+        # The variants come from the schema, joined with " or ".
+        assert "string or array of string" in message
+
+    def test_offender_excerpt_uses_double_quotes_and_keeps_unicode(self) -> None:
+        # The excerpt should be JSON-quoted (double quotes) for
+        # consistency with the example block, and non-ASCII characters
+        # should remain readable rather than be backslash-escaped.
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember", {"content": "<content>今日は雨</content>"}
+            )
+        message = str(exc_info.value)
+        assert '"<content>今日は雨</content>"' in message
+        assert "\\u" not in message

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -28,6 +28,40 @@ class TestValidateToolArguments:
         with pytest.raises(ToolParameterFormatError):
             validate_tool_arguments("forget", {"memory_id": "<memory_id/>"})
 
+    def test_rejects_named_tag_with_attributes(self) -> None:
+        # XML wrappers occasionally arrive with attributes
+        # (e.g. `<content type="text">...</content>`); the malformed
+        # payload must still be flagged so the model can self-correct.
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember",
+                {"content": '<content type="text">hello</content>'},
+            )
+        message = str(exc_info.value)
+        assert "`content`" in message
+
+    def test_rejects_self_closing_named_tag_with_attributes(self) -> None:
+        with pytest.raises(ToolParameterFormatError):
+            validate_tool_arguments(
+                "forget", {"memory_id": '<memory_id ref="abc"/>'}
+            )
+
+    def test_rejects_named_tag_with_whitespace_in_closing(self) -> None:
+        # Some serializers emit `</content >` with trailing whitespace
+        # before the closing `>`; treat it the same as `</content>`.
+        with pytest.raises(ToolParameterFormatError):
+            validate_tool_arguments(
+                "remember", {"content": "<content>hi</content >"}
+            )
+
+    def test_sibling_tag_name_prefix_does_not_match(self) -> None:
+        # `<contentx>` is a different tag name and must not collide with
+        # `content`. The attribute branch requires a leading whitespace
+        # separator, so this stays a non-match.
+        validate_tool_arguments(
+            "remember", {"content": "<contentx>noise</contentx>"}
+        )
+
     def test_rejects_xml_wrapping_numeric_parameter(self) -> None:
         with pytest.raises(ToolParameterFormatError) as exc_info:
             validate_tool_arguments(

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -110,6 +110,17 @@ class TestValidateToolArguments:
             {"field": "bio", "value": "<user>Alice</user> says hi"},
         )
 
+    def test_allows_sibling_parameter_tag_name_in_content(self) -> None:
+        # `content` intentionally quoting another parameter name like
+        # `emotion` must not be flagged. The scanner only matches a tag
+        # against its own enclosing key.
+        validate_tool_arguments(
+            "remember", {"content": "<emotion>joy</emotion>"}
+        )
+        validate_tool_arguments(
+            "recall", {"context": "look up <category>daily</category> notes"}
+        )
+
     def test_valid_consider_them_passes(self) -> None:
         validate_tool_arguments("consider_them", {"person": "Alice"})
 

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -187,14 +187,27 @@ class TestValidateToolArguments:
         for optional in ("emotion", "importance", "category"):
             assert optional in message
 
-    def test_excerpt_is_truncated(self) -> None:
+    def test_error_message_does_not_echo_offending_value(self) -> None:
+        # The correction string is returned as normal tool output and
+        # may be persisted in logs. `remember` can carry `private=true`
+        # memory text, so we must never echo the value content — only
+        # parameter names.
+        secret = "super-secret-passphrase-98765"
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "remember", {"content": f"<content>{secret}</content>"}
+            )
+        message = str(exc_info.value)
+        assert secret not in message
+        assert "`content`" in message
+
+    def test_error_message_does_not_echo_long_offending_value(self) -> None:
         long_value = "<content>" + ("x" * 500) + "</content>"
         with pytest.raises(ToolParameterFormatError) as exc_info:
             validate_tool_arguments("remember", {"content": long_value})
         message = str(exc_info.value)
-        assert "..." in message
-        # Excerpt shouldn't dump the entire payload
-        assert message.count("x") < 200
+        # No value echoed at all — not even an excerpt.
+        assert "x" * 20 not in message
 
     def test_configure_desires_enum_rendered_in_expected_shape(self) -> None:
         # When the schema has `enum`, the expected-shape section should
@@ -243,14 +256,36 @@ class TestValidateToolArguments:
         # The variants come from the schema, joined with " or ".
         assert "string or array of string" in message
 
-    def test_offender_excerpt_uses_double_quotes_and_keeps_unicode(self) -> None:
-        # The excerpt should be JSON-quoted (double quotes) for
-        # consistency with the example block, and non-ASCII characters
-        # should remain readable rather than be backslash-escaped.
+    def test_error_message_does_not_echo_unicode_offending_value(self) -> None:
+        # Same privacy rule for non-ASCII content: the message must
+        # report the parameter name without reproducing the value.
         with pytest.raises(ToolParameterFormatError) as exc_info:
             validate_tool_arguments(
                 "remember", {"content": "<content>今日は雨</content>"}
             )
         message = str(exc_info.value)
-        assert '"<content>今日は雨</content>"' in message
-        assert "\\u" not in message
+        assert "今日は雨" not in message
+        assert "`content`" in message
+
+    def test_allows_embedded_wrapper_substring(self) -> None:
+        # A value that *mentions* `<content>...</content>` inside longer
+        # free text (documentation, code samples, tutorials) is not a
+        # wrapper misuse — only the whole trimmed value counts. This
+        # avoids rejecting legitimate prose.
+        validate_tool_arguments(
+            "remember",
+            {
+                "content": (
+                    "Here's how it renders: <content>hi</content> "
+                    "— mentioned in a tutorial."
+                )
+            },
+        )
+
+    def test_rejects_wrapper_with_surrounding_whitespace(self) -> None:
+        # Incidental whitespace around a wrapper still counts as
+        # wrapper misuse; the fullmatch check trims before comparing.
+        with pytest.raises(ToolParameterFormatError):
+            validate_tool_arguments(
+                "remember", {"content": "  <content>hi</content>\n"}
+            )

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -28,14 +28,6 @@ class TestValidateToolArguments:
         with pytest.raises(ToolParameterFormatError):
             validate_tool_arguments("forget", {"memory_id": "<memory_id/>"})
 
-    def test_rejects_multiple_xml_tags_even_when_names_unknown(self) -> None:
-        # `forget` only knows `memory_id`; but multi-tag XML blob is still
-        # a clear XML misuse.
-        with pytest.raises(ToolParameterFormatError):
-            validate_tool_arguments(
-                "forget", {"memory_id": "<id>42</id><type>x</type>"}
-            )
-
     def test_rejects_xml_wrapping_numeric_parameter(self) -> None:
         with pytest.raises(ToolParameterFormatError) as exc_info:
             validate_tool_arguments(
@@ -93,6 +85,29 @@ class TestValidateToolArguments:
         # Prose with `<` characters must not trip the validator.
         validate_tool_arguments(
             "remember", {"content": "a < b < c and 3 > 2, but not <3"}
+        )
+
+    def test_allows_html_snippets_mentioned_in_content(self) -> None:
+        # Content that legitimately mentions HTML/XML tags (but none
+        # whose name is a `remember` parameter) must be accepted.
+        validate_tool_arguments(
+            "remember",
+            {"content": "Use <div> and <span> for inline HTML structure."},
+        )
+
+    def test_allows_intentional_xml_snippet_when_tag_not_a_parameter(self) -> None:
+        # Saving an XML snippet as a memory is legitimate when the tag
+        # name doesn't collide with a tool parameter.
+        validate_tool_arguments(
+            "remember", {"content": "<note>important memo</note>"}
+        )
+
+    def test_allows_update_self_value_containing_html(self) -> None:
+        # `update_self.value` accepts any type; an HTML-like string whose
+        # tag names aren't parameter names must pass.
+        validate_tool_arguments(
+            "update_self",
+            {"field": "bio", "value": "<user>Alice</user> says hi"},
         )
 
     def test_valid_consider_them_passes(self) -> None:

--- a/ego-mcp/tests/test_server_param_validation.py
+++ b/ego-mcp/tests/test_server_param_validation.py
@@ -145,11 +145,31 @@ class TestValidateToolArguments:
 
     def test_configure_desires_enum_rendered_in_expected_shape(self) -> None:
         # When the schema has `enum`, the expected-shape section should
-        # surface the allowed values rather than a bare type.
+        # surface the allowed values as valid JSON string literals so an
+        # LLM copying the sample produces a valid payload.
         with pytest.raises(ToolParameterFormatError) as exc_info:
             validate_tool_arguments(
                 "configure_desires", {"action": "<action>check</action>"}
             )
         message = str(exc_info.value)
-        assert "'check'" in message
-        assert "'set_sentence'" in message
+        assert '"check"' in message
+        assert '"set_sentence"' in message
+        # Double-quoted, not Python repr's single quotes.
+        assert "'check'" not in message
+
+    def test_enum_example_value_is_valid_json(self) -> None:
+        # The sample "Example of a correct call" must actually parse as
+        # JSON — otherwise an LLM mimicking it produces another malformed
+        # request and loops.
+        import json as _json
+        import re as _re
+
+        with pytest.raises(ToolParameterFormatError) as exc_info:
+            validate_tool_arguments(
+                "curate_notions", {"action": "<action>list</action>"}
+            )
+        message = str(exc_info.value)
+        match = _re.search(r"Example of a correct call:\n(\s*\{.*\})", message)
+        assert match is not None, message
+        parsed = _json.loads(match.group(1).strip())
+        assert parsed["action"] == "list"


### PR DESCRIPTION
LLMs sometimes call MCP tools with values wrapped in XML tags (e.g.
`{"content": "<content>hello</content>"}`). Previously these reached
handlers unchanged, producing confusing downstream errors. A narrow
pre-dispatch validator now detects named-tag / whole-tag / multi-tag
values and returns a structured message that names the offending
parameter, renders the expected JSON shape from the tool schema, and
shows a minimal correct example — so the model can self-correct on
its next turn. Errors are returned as tool output rather than raised,
so the LLM actually sees them.

https://claude.ai/code/session_01MXUnapdjpycrmJ5DS1sMg1