### PR TITLE
動的欲求に自然な充足パス(固定→動的のカスケード)を追加 (#31)

### DIFF
--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "1.0.1"
+version = "1.1.0"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.14"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_configure_desires.py
@@ -11,6 +11,7 @@ from ego_mcp.desire_catalog import (
     ensure_default_desire_catalog_file,
     load_desire_catalog,
 )
+from ego_mcp.emergent_desires import EMERGENT_DESIRE_BY_ID
 
 
 def _handle_configure_desires(
@@ -51,7 +52,28 @@ def _handle_configure_desires(
             return "set_signals requires desire_id and signals (list of strings)."
         return _set_signals(path, payload, desire_id, [str(s) for s in signals])
 
-    return f"Unknown action: {action}. Use check, show, set_sentence, or set_signals."
+    if action == "set_emergent_satisfaction":
+        desire_id = str(args.get("desire_id", "")).strip()
+        emergent_id = str(args.get("emergent_id", "")).strip()
+        quality_raw = args.get("quality")
+        if (
+            not desire_id
+            or not emergent_id
+            or not isinstance(quality_raw, (int, float))
+            or isinstance(quality_raw, bool)
+        ):
+            return (
+                "set_emergent_satisfaction requires desire_id, emergent_id, "
+                "and quality (number)."
+            )
+        return _set_emergent_satisfaction(
+            path, payload, desire_id, emergent_id, float(quality_raw)
+        )
+
+    return (
+        f"Unknown action: {action}. "
+        "Use check, show, set_sentence, set_signals, or set_emergent_satisfaction."
+    )
 
 
 def _load_catalog_payload(path: Path) -> dict[str, Any]:
@@ -104,6 +126,9 @@ def _show_one(
     implicit = desire.get("implicit_satisfaction", {})
     if isinstance(implicit, dict) and implicit:
         lines.append(f"  implicit_satisfaction: {implicit}")
+    emergent_cascade = desire.get("implicit_emergent_satisfaction", {})
+    if isinstance(emergent_cascade, dict) and emergent_cascade:
+        lines.append(f"  implicit_emergent_satisfaction: {emergent_cascade}")
     if catalog_error is not None:
         lines.append(f"  validation: {catalog_error}")
     return "\n".join(lines)
@@ -177,6 +202,36 @@ def _set_signals(
     return _write_result(
         path,
         f"Updated {desire_id}.satisfaction_signals ({len(signals)} signal(s))",
+    )
+
+
+def _set_emergent_satisfaction(
+    path: Path,
+    payload: dict[str, Any],
+    desire_id: str,
+    emergent_id: str,
+    quality: float,
+) -> str:
+    desires = _fixed_desire_payloads(payload)
+    if desire_id not in desires:
+        return f"Unknown desire: {desire_id}"
+    if emergent_id not in EMERGENT_DESIRE_BY_ID:
+        known = ", ".join(sorted(EMERGENT_DESIRE_BY_ID))
+        return f"Unknown emergent desire: {emergent_id}. Known: {known}"
+    if not 0.5 <= quality <= 1.0:
+        return (
+            f"quality must be within 0.5 <= quality <= 1.0 (got {quality})."
+        )
+
+    cascade = desires[desire_id].setdefault("implicit_emergent_satisfaction", {})
+    if not isinstance(cascade, dict):
+        cascade = {}
+        desires[desire_id]["implicit_emergent_satisfaction"] = cascade
+    cascade[emergent_id] = quality
+    _write_payload(path, payload)
+    return _write_result(
+        path,
+        f"Updated {desire_id}.implicit_emergent_satisfaction.{emergent_id} = {quality}",
     )
 
 

--- a/ego-mcp/src/ego_mcp/_server_tools.py
+++ b/ego-mcp/src/ego_mcp/_server_tools.py
@@ -271,7 +271,13 @@ BACKEND_TOOLS: list[Tool] = [
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["check", "set_sentence", "set_signals", "show"],
+                    "enum": [
+                        "check",
+                        "set_sentence",
+                        "set_signals",
+                        "set_emergent_satisfaction",
+                        "show",
+                    ],
                 },
                 "desire_id": {"type": "string", "description": "Desire ID."},
                 "direction": {
@@ -287,6 +293,14 @@ BACKEND_TOOLS: list[Tool] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Satisfaction signals for set_signals.",
+                },
+                "emergent_id": {
+                    "type": "string",
+                    "description": "Emergent desire ID for cascade.",
+                },
+                "quality": {
+                    "type": "number",
+                    "description": "Cascade quality 0.5–1.0.",
                 },
             },
             "required": ["action"],

--- a/ego-mcp/src/ego_mcp/desire.py
+++ b/ego-mcp/src/ego_mcp/desire.py
@@ -455,18 +455,40 @@ class DesireEngine:
             if isinstance(state, dict) and not state.get("is_emergent", False)
         }
 
-    def satisfy(self, name: str, quality: float = 0.7) -> float:
-        """Mark a desire as satisfied. Returns new level."""
-        self.require_valid_catalog()
-        canonical_name = self._canonical_desire_name(name)
-        if not self._is_known_desire(canonical_name):
-            raise ValueError(f"Unknown desire: {name}")
+    def _apply_satisfy(self, canonical_name: str, quality: float) -> None:
+        """Mutate in-memory state for a satisfied desire. No persistence or recomputation."""
         now = timezone_utils.now().isoformat()
         if canonical_name not in self._state:
             self._state[canonical_name] = {}
         self._state[canonical_name]["last_satisfied"] = now
-        self._state[canonical_name]["satisfaction_quality"] = max(0.0, min(1.0, quality))
+        self._state[canonical_name]["satisfaction_quality"] = max(
+            0.0, min(1.0, quality)
+        )
         self._state[canonical_name]["boost"] = 0.0
+
+    def satisfy(self, name: str, quality: float = 0.7) -> float:
+        """Mark a desire as satisfied. Returns new level.
+
+        When ``name`` is a fixed desire that declares
+        ``implicit_emergent_satisfaction`` in the catalog, each mapped emergent
+        desire that is currently active in state is also satisfied with the
+        catalog-configured quality. Cascade never creates emergent entries and
+        never chains (emergent targets have no fixed-desire config).
+        """
+        catalog = self.require_valid_catalog()
+        canonical_name = self._canonical_desire_name(name)
+        if not self._is_known_desire(canonical_name):
+            raise ValueError(f"Unknown desire: {name}")
+
+        self._apply_satisfy(canonical_name, quality)
+
+        fixed = catalog.fixed_desires.get(canonical_name)
+        if fixed is not None:
+            for target_id, target_quality in fixed.implicit_emergent_satisfaction.items():
+                target_state = self._state.get(target_id)
+                if target_state is not None and target_state.get("is_emergent"):
+                    self._apply_satisfy(target_id, target_quality)
+
         self.save_state()
         return self.compute_levels().get(canonical_name, 0.0)
 

--- a/ego-mcp/src/ego_mcp/desire_catalog.py
+++ b/ego-mcp/src/ego_mcp/desire_catalog.py
@@ -23,6 +23,7 @@ BUILTIN_FIXED_DESIRES: dict[str, dict[str, Any]] = {
             "discovering an interesting idea",
             "understanding something that was unclear",
         ],
+        "implicit_emergent_satisfaction": {"grasp_something": 0.5},
     },
     "social_thirst": {
         "satisfaction_hours": 24.0,
@@ -41,6 +42,7 @@ BUILTIN_FIXED_DESIRES: dict[str, dict[str, Any]] = {
             "feeling heard by someone",
             "connecting with another person",
         ],
+        "implicit_emergent_satisfaction": {"be_with_someone": 0.5},
     },
     "cognitive_coherence": {
         "satisfaction_hours": 18.0,
@@ -60,6 +62,7 @@ BUILTIN_FIXED_DESIRES: dict[str, dict[str, Any]] = {
             "finding a pattern that connects things",
             "resolving an inner contradiction",
         ],
+        "implicit_emergent_satisfaction": {"feel_safe": 0.5},
     },
     "pattern_seeking": {
         "satisfaction_hours": 72.0,
@@ -125,6 +128,7 @@ BUILTIN_FIXED_DESIRES: dict[str, dict[str, Any]] = {
             "sharing an emotional moment",
             "seeing the world through their eyes",
         ],
+        "implicit_emergent_satisfaction": {"be_with_someone": 0.5},
     },
     "expression": {
         "satisfaction_hours": 24.0,
@@ -155,6 +159,7 @@ BUILTIN_FIXED_DESIRES: dict[str, dict[str, Any]] = {
             "exploring something unknown",
             "satisfying a question",
         ],
+        "implicit_emergent_satisfaction": {"grasp_something": 0.5},
     },
 }
 
@@ -193,6 +198,7 @@ class FixedDesireConfig(BaseModel):
     sentence: DesireSentenceConfig
     implicit_satisfaction: dict[str, float] = Field(default_factory=dict)
     satisfaction_signals: list[str] = Field(default_factory=list)
+    implicit_emergent_satisfaction: dict[str, float] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_qualities(self) -> FixedDesireConfig:
@@ -200,6 +206,11 @@ class FixedDesireConfig(BaseModel):
             if not 0.0 < float(quality) <= 1.0:
                 raise ValueError(
                     f"implicit_satisfaction.{tool_name} must be within 0 < quality <= 1"
+                )
+        for emergent_id, quality in self.implicit_emergent_satisfaction.items():
+            if not 0.5 <= float(quality) <= 1.0:
+                raise ValueError(
+                    f"implicit_emergent_satisfaction.{emergent_id} must be within 0.5 <= quality <= 1"
                 )
         return self
 
@@ -322,6 +333,9 @@ def _default_fixed_desires() -> dict[str, FixedDesireConfig]:
             sentence=DesireSentenceConfig.model_validate(payload["sentence"]),
             implicit_satisfaction=dict(payload["implicit_satisfaction"]),
             satisfaction_signals=list(payload.get("satisfaction_signals", [])),
+            implicit_emergent_satisfaction=dict(
+                payload.get("implicit_emergent_satisfaction", {})
+            ),
         )
         for desire_id, payload in BUILTIN_FIXED_DESIRES.items()
     }

--- a/ego-mcp/src/ego_mcp/migrations/0008_emergent_cascade_defaults.py
+++ b/ego-mcp/src/ego_mcp/migrations/0008_emergent_cascade_defaults.py
@@ -1,0 +1,72 @@
+"""Seed default implicit_emergent_satisfaction entries for existing catalogs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+TARGET_VERSION = "1.1.0"
+
+_BACKUP_FILENAME = "desires.pre_0008_emergent_cascade.json"
+
+_DEFAULTS: dict[str, dict[str, float]] = {
+    "curiosity":           {"grasp_something": 0.5},
+    "information_hunger":  {"grasp_something": 0.5},
+    "social_thirst":       {"be_with_someone": 0.5},
+    "resonance":           {"be_with_someone": 0.5},
+    "cognitive_coherence": {"feel_safe":       0.5},
+}
+
+
+def _apply_defaults(payload: dict[str, Any]) -> bool:
+    """Add missing cascade defaults to the catalog payload. Returns True if changed."""
+    fixed = payload.get("fixed_desires")
+    if not isinstance(fixed, dict):
+        return False
+
+    changed = False
+    for desire_id, defaults in _DEFAULTS.items():
+        desire_config = fixed.get(desire_id)
+        if not isinstance(desire_config, dict):
+            continue
+
+        existing = desire_config.get("implicit_emergent_satisfaction")
+        if not isinstance(existing, dict):
+            desire_config["implicit_emergent_satisfaction"] = dict(defaults)
+            changed = True
+            continue
+
+        for emergent_id, quality in defaults.items():
+            if emergent_id not in existing:
+                existing[emergent_id] = quality
+                changed = True
+    return changed
+
+
+def up(data_dir: Path) -> None:
+    """Add default implicit_emergent_satisfaction entries to settings/desires.json."""
+    catalog_path = data_dir / "settings" / "desires.json"
+    if not catalog_path.exists():
+        return
+
+    try:
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+
+    if not isinstance(payload, dict):
+        return
+
+    if not _apply_defaults(payload):
+        return
+
+    backup_path = catalog_path.parent / _BACKUP_FILENAME
+    if not backup_path.exists():
+        original_text = catalog_path.read_text(encoding="utf-8")
+        backup_path.write_text(original_text, encoding="utf-8")
+
+    catalog_path.write_text(
+        json.dumps(cast(dict[str, Any], payload), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )

--- a/ego-mcp/tests/test_configure_desires.py
+++ b/ego-mcp/tests/test_configure_desires.py
@@ -148,3 +148,120 @@ class TestConfigureDesires:
         assert "Catalog still has validation issues:" in result
         payload = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert payload["fixed_desires"]["curiosity"]["sentence"]["settling"] == "Quiet again."
+
+
+class TestConfigureDesiresEmergentSatisfaction:
+    """configure_desires set_emergent_satisfaction action (issue #31)."""
+
+    def test_set_emergent_satisfaction_updates_catalog(
+        self, catalog_path: Path
+    ) -> None:
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_emergent_satisfaction",
+                "desire_id": "curiosity",
+                "emergent_id": "grasp_something",
+                "quality": 0.7,
+            },
+        )
+        assert "Updated curiosity.implicit_emergent_satisfaction.grasp_something" in result
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        cascade = payload["fixed_desires"]["curiosity"]["implicit_emergent_satisfaction"]
+        assert cascade["grasp_something"] == 0.7
+
+    def test_set_emergent_satisfaction_missing_params(
+        self, catalog_path: Path
+    ) -> None:
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {"action": "set_emergent_satisfaction", "desire_id": "curiosity"},
+        )
+        assert "requires" in result
+
+    def test_set_emergent_satisfaction_rejects_unknown_desire(
+        self, catalog_path: Path
+    ) -> None:
+        before = catalog_path.read_text(encoding="utf-8")
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_emergent_satisfaction",
+                "desire_id": "nonexistent",
+                "emergent_id": "grasp_something",
+                "quality": 0.7,
+            },
+        )
+        assert "Unknown desire: nonexistent" in result
+        assert catalog_path.read_text(encoding="utf-8") == before
+
+    def test_set_emergent_satisfaction_rejects_unknown_emergent(
+        self, catalog_path: Path
+    ) -> None:
+        before = catalog_path.read_text(encoding="utf-8")
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_emergent_satisfaction",
+                "desire_id": "curiosity",
+                "emergent_id": "not_a_real_emergent",
+                "quality": 0.7,
+            },
+        )
+        assert "Unknown emergent desire: not_a_real_emergent" in result
+        assert catalog_path.read_text(encoding="utf-8") == before
+
+    def test_set_emergent_satisfaction_rejects_below_floor(
+        self, catalog_path: Path
+    ) -> None:
+        before = catalog_path.read_text(encoding="utf-8")
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_emergent_satisfaction",
+                "desire_id": "curiosity",
+                "emergent_id": "grasp_something",
+                "quality": 0.3,
+            },
+        )
+        assert "0.5" in result
+        assert catalog_path.read_text(encoding="utf-8") == before
+
+    def test_set_emergent_satisfaction_rejects_above_one(
+        self, catalog_path: Path
+    ) -> None:
+        before = catalog_path.read_text(encoding="utf-8")
+        result = _handle_configure_desires(
+            str(catalog_path),
+            {
+                "action": "set_emergent_satisfaction",
+                "desire_id": "curiosity",
+                "emergent_id": "grasp_something",
+                "quality": 1.1,
+            },
+        )
+        assert "1" in result
+        assert catalog_path.read_text(encoding="utf-8") == before
+
+    def test_show_one_includes_implicit_emergent_satisfaction(
+        self, catalog_path: Path
+    ) -> None:
+        result = _handle_configure_desires(
+            str(catalog_path), {"action": "show", "desire_id": "curiosity"}
+        )
+        assert "implicit_emergent_satisfaction" in result
+        assert "grasp_something" in result
+
+    def test_check_does_not_flag_missing_emergent_cascade(
+        self, catalog_path: Path
+    ) -> None:
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+        # expression has no cascade entry by default; ensure check does not complain
+        assert (
+            payload["fixed_desires"].get("expression", {}).get(
+                "implicit_emergent_satisfaction", {}
+            )
+            == {}
+        )
+        result = _handle_configure_desires(str(catalog_path), {"action": "check"})
+        assert "missing implicit_emergent_satisfaction" not in result

--- a/ego-mcp/tests/test_desire.py
+++ b/ego-mcp/tests/test_desire.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import importlib
 import json
+from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -815,3 +817,204 @@ class TestGenerateEmergentFromRecentMemories:
         # Explicit override to 2 — should succeed
         result = generate_emergent_from_recent_memories(engine, mems, min_memories=2)
         assert result is not None
+
+
+class TestCascadeSatisfaction:
+    """Fixed desire satisfaction cascades into active emergent desires (issue #31)."""
+
+    @pytest.fixture
+    def engine(self, tmp_path: Path) -> DesireEngine:
+        return DesireEngine.from_data_dir(tmp_path)
+
+    @staticmethod
+    def _seed_emergent(engine: DesireEngine, name: str) -> None:
+        engine._state[name] = {
+            "last_satisfied": "",
+            "satisfaction_quality": 0.5,
+            "boost": 0.0,
+            "is_emergent": True,
+            "created": datetime.now(timezone.utc).isoformat(),
+            "satisfaction_hours": 24.0,
+        }
+
+    @staticmethod
+    def _write_catalog(
+        tmp_path: Path,
+        mutate: Callable[[dict[str, Any]], None],
+    ) -> Path:
+        path = desire_catalog_settings_path(tmp_path)
+        payload = default_desire_catalog().model_dump(mode="json")
+        mutate(payload)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_satisfying_curiosity_cascades_to_active_grasp_something(
+        self, engine: DesireEngine
+    ) -> None:
+        self._seed_emergent(engine, "grasp_something")
+        engine.satisfy("curiosity", quality=0.9)
+        target = engine._state["grasp_something"]
+        assert target["last_satisfied"] != ""
+        assert target["satisfaction_quality"] == 0.5
+
+    def test_cascade_quality_comes_from_catalog_not_source(
+        self, tmp_path: Path
+    ) -> None:
+        def mutate(payload: dict[str, Any]) -> None:
+            fixed = payload["fixed_desires"]
+            fixed["curiosity"]["implicit_emergent_satisfaction"] = {
+                "grasp_something": 0.7,
+            }
+
+        self._write_catalog(tmp_path, mutate)
+        engine = DesireEngine.from_data_dir(tmp_path)
+        self._seed_emergent(engine, "grasp_something")
+        engine.satisfy("curiosity", quality=0.9)
+        assert engine._state["grasp_something"]["satisfaction_quality"] == 0.7
+
+    def test_cascade_noop_when_target_not_active(self, engine: DesireEngine) -> None:
+        assert "grasp_something" not in engine._state
+        engine.satisfy("curiosity", quality=0.9)
+        assert "grasp_something" not in engine._state
+
+    def test_cascade_does_not_chain_from_emergent(self, engine: DesireEngine) -> None:
+        self._seed_emergent(engine, "grasp_something")
+        self._seed_emergent(engine, "feel_safe")
+        self._seed_emergent(engine, "be_with_someone")
+        engine.satisfy("grasp_something", quality=0.8)
+        assert engine._state["grasp_something"]["last_satisfied"] != ""
+        assert engine._state["feel_safe"]["last_satisfied"] == ""
+        assert engine._state["be_with_someone"]["last_satisfied"] == ""
+
+    def test_non_mapped_fixed_desire_no_cascade(self, engine: DesireEngine) -> None:
+        self._seed_emergent(engine, "grasp_something")
+        self._seed_emergent(engine, "feel_safe")
+        self._seed_emergent(engine, "be_with_someone")
+        engine.satisfy("expression", quality=0.8)
+        assert engine._state["grasp_something"]["last_satisfied"] == ""
+        assert engine._state["feel_safe"]["last_satisfied"] == ""
+        assert engine._state["be_with_someone"]["last_satisfied"] == ""
+
+    def test_preserves_primary_quality(self, engine: DesireEngine) -> None:
+        self._seed_emergent(engine, "grasp_something")
+        engine.satisfy("curiosity", quality=0.9)
+        assert engine._state["curiosity"]["satisfaction_quality"] == 0.9
+        assert engine._state["grasp_something"]["satisfaction_quality"] == 0.5
+
+    def test_multiple_cascade_targets(self, tmp_path: Path) -> None:
+        def mutate(payload: dict[str, Any]) -> None:
+            fixed = payload["fixed_desires"]
+            fixed["curiosity"]["implicit_emergent_satisfaction"] = {
+                "grasp_something": 0.6,
+                "feel_safe": 0.8,
+            }
+
+        self._write_catalog(tmp_path, mutate)
+        engine = DesireEngine.from_data_dir(tmp_path)
+        self._seed_emergent(engine, "grasp_something")
+        self._seed_emergent(engine, "feel_safe")
+        engine.satisfy("curiosity", quality=0.9)
+        assert engine._state["grasp_something"]["satisfaction_quality"] == 0.6
+        assert engine._state["grasp_something"]["last_satisfied"] != ""
+        assert engine._state["feel_safe"]["satisfaction_quality"] == 0.8
+        assert engine._state["feel_safe"]["last_satisfied"] != ""
+
+    def test_information_hunger_cascades_to_grasp_something(
+        self, engine: DesireEngine
+    ) -> None:
+        self._seed_emergent(engine, "grasp_something")
+        engine.satisfy("information_hunger", quality=0.9)
+        assert engine._state["grasp_something"]["last_satisfied"] != ""
+
+    def test_social_thirst_cascades_to_be_with_someone(
+        self, engine: DesireEngine
+    ) -> None:
+        self._seed_emergent(engine, "be_with_someone")
+        engine.satisfy("social_thirst", quality=0.9)
+        assert engine._state["be_with_someone"]["last_satisfied"] != ""
+
+    def test_resonance_cascades_to_be_with_someone(
+        self, engine: DesireEngine
+    ) -> None:
+        self._seed_emergent(engine, "be_with_someone")
+        engine.satisfy("resonance", quality=0.9)
+        assert engine._state["be_with_someone"]["last_satisfied"] != ""
+
+    def test_cognitive_coherence_cascades_to_feel_safe(
+        self, engine: DesireEngine
+    ) -> None:
+        self._seed_emergent(engine, "feel_safe")
+        engine.satisfy("cognitive_coherence", quality=0.9)
+        assert engine._state["feel_safe"]["last_satisfied"] != ""
+
+
+class TestImplicitEmergentSatisfactionCatalog:
+    """Catalog-level schema for implicit_emergent_satisfaction (issue #31)."""
+
+    def test_default_catalog_has_five_builtin_cascade_pairs(self) -> None:
+        catalog = default_desire_catalog()
+        fixed = catalog.fixed_desires
+        assert fixed["curiosity"].implicit_emergent_satisfaction == {
+            "grasp_something": 0.5,
+        }
+        assert fixed["information_hunger"].implicit_emergent_satisfaction == {
+            "grasp_something": 0.5,
+        }
+        assert fixed["social_thirst"].implicit_emergent_satisfaction == {
+            "be_with_someone": 0.5,
+        }
+        assert fixed["resonance"].implicit_emergent_satisfaction == {
+            "be_with_someone": 0.5,
+        }
+        assert fixed["cognitive_coherence"].implicit_emergent_satisfaction == {
+            "feel_safe": 0.5,
+        }
+
+    @staticmethod
+    def _write_with_cascade(
+        tmp_path: Path, desire_id: str, cascade: dict[str, float]
+    ) -> Path:
+        path = desire_catalog_settings_path(tmp_path)
+        payload = default_desire_catalog().model_dump(mode="json")
+        payload["fixed_desires"][desire_id]["implicit_emergent_satisfaction"] = cascade
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_rejects_below_floor(self, tmp_path: Path) -> None:
+        path = self._write_with_cascade(
+            tmp_path, "curiosity", {"grasp_something": 0.4}
+        )
+        with pytest.raises(
+            DesireConfigurationError,
+            match="implicit_emergent_satisfaction.grasp_something",
+        ):
+            load_desire_catalog(path)
+
+    def test_rejects_above_one(self, tmp_path: Path) -> None:
+        path = self._write_with_cascade(
+            tmp_path, "curiosity", {"grasp_something": 1.1}
+        )
+        with pytest.raises(
+            DesireConfigurationError,
+            match="implicit_emergent_satisfaction.grasp_something",
+        ):
+            load_desire_catalog(path)
+
+    def test_accepts_floor_and_ceiling(self, tmp_path: Path) -> None:
+        path = self._write_with_cascade(
+            tmp_path,
+            "curiosity",
+            {"grasp_something": 0.5, "feel_safe": 1.0},
+        )
+        catalog = load_desire_catalog(path)
+        cascade = catalog.fixed_desires["curiosity"].implicit_emergent_satisfaction
+        assert cascade["grasp_something"] == 0.5
+        assert cascade["feel_safe"] == 1.0

--- a/ego-mcp/tests/test_migrations.py
+++ b/ego-mcp/tests/test_migrations.py
@@ -703,3 +703,185 @@ class TestEmergentDesireIdMigration:
         assert payload["grasp_something"]["satisfaction_quality"] == 0.9
         assert payload["grasp_something"]["satisfaction_hours"] == 24.0
         assert "You want to grasp something." not in payload
+
+
+class TestEmergentCascadeDefaultsMigration:
+    """0008_emergent_cascade_defaults adds implicit_emergent_satisfaction defaults (issue #31)."""
+
+    @pytest.fixture
+    def migration_mod(self) -> object:
+        return __import__(
+            "ego_mcp.migrations.0008_emergent_cascade_defaults",
+            fromlist=["up"],
+        )
+
+    def _catalog_path(self, data_dir: Path) -> Path:
+        return data_dir / "settings" / "desires.json"
+
+    def _backup_path(self, data_dir: Path) -> Path:
+        return data_dir / "settings" / "desires.pre_0008_emergent_cascade.json"
+
+    def _write(self, data_dir: Path, payload: dict[str, Any]) -> None:
+        path = self._catalog_path(data_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    def _read(self, data_dir: Path) -> dict[str, Any]:
+        raw: dict[str, Any] = json.loads(
+            self._catalog_path(data_dir).read_text(encoding="utf-8")
+        )
+        return raw
+
+    def _minimal_v2(self) -> dict[str, Any]:
+        def _fixed(
+            hours: float, level: int, extra: dict[str, Any] | None = None
+        ) -> dict[str, Any]:
+            base: dict[str, Any] = {
+                "satisfaction_hours": hours,
+                "maslow_level": level,
+                "sentence": {"rising": "r", "steady": "s", "settling": "t"},
+                "implicit_satisfaction": {},
+                "satisfaction_signals": [],
+            }
+            if extra:
+                base.update(extra)
+            return base
+
+        return {
+            "version": 2,
+            "fixed_desires": {
+                "curiosity": _fixed(18.0, 4),
+                "information_hunger": _fixed(12.0, 1),
+                "social_thirst": _fixed(24.0, 1),
+                "resonance": _fixed(30.0, 3),
+                "cognitive_coherence": _fixed(18.0, 1),
+                "expression": _fixed(24.0, 4),
+            },
+            "emergent": {
+                "satisfaction_hours": 24.0,
+                "expiry_hours": 72.0,
+                "satisfied_ttl_hours": 168.0,
+            },
+        }
+
+    def test_adds_defaults_to_existing_catalog(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        self._write(tmp_path, self._minimal_v2())
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        result = self._read(tmp_path)
+        fixed = result["fixed_desires"]
+        assert fixed["curiosity"]["implicit_emergent_satisfaction"] == {
+            "grasp_something": 0.5
+        }
+        assert fixed["information_hunger"]["implicit_emergent_satisfaction"] == {
+            "grasp_something": 0.5
+        }
+        assert fixed["social_thirst"]["implicit_emergent_satisfaction"] == {
+            "be_with_someone": 0.5
+        }
+        assert fixed["resonance"]["implicit_emergent_satisfaction"] == {
+            "be_with_someone": 0.5
+        }
+        assert fixed["cognitive_coherence"]["implicit_emergent_satisfaction"] == {
+            "feel_safe": 0.5
+        }
+        # Non-source desires are left without the field
+        assert "implicit_emergent_satisfaction" not in fixed["expression"]
+
+    def test_preserves_existing_user_values(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        payload = self._minimal_v2()
+        payload["fixed_desires"]["curiosity"]["implicit_emergent_satisfaction"] = {
+            "grasp_something": 0.8,
+        }
+        self._write(tmp_path, payload)
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        result = self._read(tmp_path)
+        assert result["fixed_desires"]["curiosity"][
+            "implicit_emergent_satisfaction"
+        ] == {"grasp_something": 0.8}
+
+    def test_adds_missing_pair_without_overwriting_existing(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        payload = self._minimal_v2()
+        payload["fixed_desires"]["curiosity"]["implicit_emergent_satisfaction"] = {
+            "feel_safe": 0.9,
+        }
+        self._write(tmp_path, payload)
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        result = self._read(tmp_path)
+        cascade = result["fixed_desires"]["curiosity"][
+            "implicit_emergent_satisfaction"
+        ]
+        assert cascade["feel_safe"] == 0.9
+        assert cascade["grasp_something"] == 0.5
+
+    def test_skips_when_source_desire_absent(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        payload = self._minimal_v2()
+        del payload["fixed_desires"]["resonance"]
+        self._write(tmp_path, payload)
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        result = self._read(tmp_path)
+        assert "resonance" not in result["fixed_desires"]
+
+    def test_writes_backup(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        self._write(tmp_path, self._minimal_v2())
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        assert self._backup_path(tmp_path).exists()
+        backup = json.loads(self._backup_path(tmp_path).read_text(encoding="utf-8"))
+        assert (
+            "implicit_emergent_satisfaction"
+            not in backup["fixed_desires"]["curiosity"]
+        )
+
+    def test_noop_when_catalog_file_missing(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+        assert not self._catalog_path(tmp_path).exists()
+
+    def test_noop_when_no_defaults_need_adding(
+        self, tmp_path: Path, migration_mod: object
+    ) -> None:
+        # Catalog already has all five pairs at non-default values — nothing to change.
+        payload = self._minimal_v2()
+        payload["fixed_desires"]["curiosity"]["implicit_emergent_satisfaction"] = {
+            "grasp_something": 0.7
+        }
+        payload["fixed_desires"]["information_hunger"][
+            "implicit_emergent_satisfaction"
+        ] = {"grasp_something": 0.7}
+        payload["fixed_desires"]["social_thirst"][
+            "implicit_emergent_satisfaction"
+        ] = {"be_with_someone": 0.7}
+        payload["fixed_desires"]["resonance"]["implicit_emergent_satisfaction"] = {
+            "be_with_someone": 0.7
+        }
+        payload["fixed_desires"]["cognitive_coherence"][
+            "implicit_emergent_satisfaction"
+        ] = {"feel_safe": 0.7}
+        self._write(tmp_path, payload)
+
+        migration_mod.up(tmp_path)  # type: ignore[attr-defined]
+
+        # No backup is created if no writes were performed.
+        assert not self._backup_path(tmp_path).exists()

--- a/ego-mcp/uv.lock
+++ b/ego-mcp/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "ego-mcp"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- 固定欲求が `satisfy` されたとき、関連する動的欲求を自動的に部分充足するカスケードを追加 (Issue #31)。
- カスケード量(quality)は `desires.json` の `FixedDesireConfig.implicit_emergent_satisfaction` で設定可能。下限 0.5 を Pydantic バリデーションで強制。
- エージェント自身が `configure_desires(action="set_emergent_satisfaction", ...)` で度合いを調整できる。
- 既存環境には migration `0008_emergent_cascade_defaults` でデフォルト値を投入(ユーザー設定は保持、バックアップ作成)。

## Key design choices

- **Absolute quality, not ratio**: `satisfy("curiosity", 0.9)` が cascade する際、対象 emergent は catalog で設定された quality(既定 0.5)で満たす。ソースの強さには連動しない。既存の `implicit_satisfaction` の仕組みと同じモデル。
- **Cascade は active な emergent にのみ作用**: target が state に存在しない場合は何も起こらない(emergent を勝手に生やさない)。
- **チェーンしない**: emergent 側には cascade 設定が無いため再帰はしない。
- **1回の `satisfy` あたり state 永続化は 1 回**: `_apply_satisfy` を private に切り出し、public `satisfy` の最後でまとめて `save_state` + `compute_levels`。

## Built-in cascade pairs (quality 0.5)

| Source fixed | → | Target emergent |
|---|---|---|
| `curiosity` / `information_hunger` | → | `grasp_something` |
| `social_thirst` / `resonance` | → | `be_with_someone` |
| `cognitive_coherence` | → | `feel_safe` |

## Files

- `desire_catalog.py`: 新フィールド + validator + BUILTIN_FIXED_DESIRES 既定値。
- `desire.py`: `_apply_satisfy` / `satisfy` リファクタと cascade 実装。
- `_server_backend_configure_desires.py` + `_server_tools.py`: `set_emergent_satisfaction` action と MCP schema 拡張、`show` で cascade マップを表示。
- `migrations/0008_emergent_cascade_defaults.py`: 既存 catalog にデフォルト投入、ユーザー値保持、`desires.pre_0008_emergent_cascade.json` にバックアップ。
- version bump: `1.0.1` → `1.1.0` (`pyproject.toml`, `__init__.py`、migration `TARGET_VERSION` 一致)。

## Test plan

TDD で以下のテストを先に書いてから実装。すべて green。

- [x] `tests/test_desire.py::TestCascadeSatisfaction` — 11 テスト (各 cascade pair、非 active 時 noop、emergent から chain しない、非 mapping desire は影響なし、multi-target、primary quality 保存)
- [x] `tests/test_desire.py::TestImplicitEmergentSatisfactionCatalog` — 4 テスト (下限 0.5 / 上限 1.0 バリデーション、default catalog に 5 pair 含む)
- [x] `tests/test_configure_desires.py::TestConfigureDesiresEmergentSatisfaction` — 8 テスト (更新成功、欠落パラメータ、不明 source、不明 emergent、下限 / 上限拒否、show に表示、check は警告しない)
- [x] `tests/test_migrations.py::TestEmergentCascadeDefaultsMigration` — 7 テスト (既存 catalog への追加、ユーザー値保持、部分追加、source 欠落時 skip、backup 作成、ファイル無し no-op、全部既存時 no-op)
- [x] ego-mcp CI gate: `pytest tests -v` (794 passed), `isort --check-only`, `ruff check`, `mypy` — すべて green

## Manual smoke test checklist

- [ ] 既存 data dir で起動 → `0008` migration が 1 回走り、`desires.json` に 5 pair + `desires.pre_0008_emergent_cascade.json` バックアップが生成される
- [ ] `configure_desires(action="show", desire_id="curiosity")` の出力に `implicit_emergent_satisfaction: {"grasp_something": 0.5}` が表示される
- [ ] `configure_desires(action="set_emergent_satisfaction", desire_id="curiosity", emergent_id="grasp_something", quality=0.7)` → 成功メッセージ + 次の `show` で 0.7 に反映
- [ ] Active な `grasp_something` を seed した状態で `remember` 等から `curiosity` が `satisfy` されると、`grasp_something.last_satisfied` も更新される (`satisfaction_quality` は catalog の値)
- [ ] 非 active 時に `curiosity` を `satisfy` しても `grasp_something` は state に生成されない
- [ ] `set_emergent_satisfaction` で `quality=0.3` を指定すると 0.5 下限を理由に拒否される

🤖 Generated with [Claude Code](https://claude.com/claude-code)