### PR TITLE
Show agent name badge in dashboard header

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -21,3 +21,6 @@ DASHBOARD_EGO_MCP_DATA_DIR=
 # Browser-facing frontend endpoints (use localhost because requests originate from the host browser)
 VITE_DASHBOARD_API_BASE=http://localhost:8000
 VITE_DASHBOARD_WS_BASE=ws://localhost:8000
+
+# Optional: agent name shown as a badge in the dashboard header. Leave blank to hide.
+VITE_DASHBOARD_AGENT_NAME=

--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     environment:
       VITE_DASHBOARD_API_BASE: ${VITE_DASHBOARD_API_BASE:-http://localhost:8000}
       VITE_DASHBOARD_WS_BASE: ${VITE_DASHBOARD_WS_BASE:-ws://localhost:8000}
+      VITE_DASHBOARD_AGENT_NAME: ${VITE_DASHBOARD_AGENT_NAME:-}
     ports:
       - "4173:4173"
     depends_on:

--- a/dashboard/frontend/src/components/layout/dashboard-header.test.tsx
+++ b/dashboard/frontend/src/components/layout/dashboard-header.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DashboardHeader } from './dashboard-header'
+
+describe('DashboardHeader', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('shows the agent name when VITE_DASHBOARD_AGENT_NAME is set', () => {
+    vi.stubEnv('VITE_DASHBOARD_AGENT_NAME', 'orchid-7')
+
+    render(<DashboardHeader current={null} connected={true} />)
+
+    expect(screen.getByLabelText('agent name')).toHaveTextContent('orchid-7')
+  })
+
+  it('omits the agent name when the env var is unset or blank', () => {
+    vi.stubEnv('VITE_DASHBOARD_AGENT_NAME', '   ')
+
+    render(<DashboardHeader current={null} connected={true} />)
+
+    expect(screen.queryByLabelText('agent name')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/layout/dashboard-header.tsx
+++ b/dashboard/frontend/src/components/layout/dashboard-header.tsx
@@ -9,14 +9,26 @@ type DashboardHeaderProps = {
 export const DashboardHeader = ({
   current,
   connected,
-}: DashboardHeaderProps) => (
-  <header className="flex items-center justify-between gap-4">
-    <div className="flex items-center gap-3">
-      <h1 className="text-xl font-bold tracking-tight">ego-mcp Dashboard</h1>
-      {!connected && (
-        <span className="text-muted-foreground text-xs">(polling)</span>
-      )}
-    </div>
-    <StatusIndicator current={current} />
-  </header>
-)
+}: DashboardHeaderProps) => {
+  const agentName = import.meta.env.VITE_DASHBOARD_AGENT_NAME?.trim() || ''
+
+  return (
+    <header className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <h1 className="text-xl font-bold tracking-tight">ego-mcp Dashboard</h1>
+        {agentName && (
+          <span
+            className="bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs font-medium"
+            aria-label="agent name"
+          >
+            {agentName}
+          </span>
+        )}
+        {!connected && (
+          <span className="text-muted-foreground text-xs">(polling)</span>
+        )}
+      </div>
+      <StatusIndicator current={current} />
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- Add optional agent name badge to the dashboard header, hidden when unset/blank
- Read from `VITE_DASHBOARD_AGENT_NAME` (passed through in `docker-compose.yml`); documented in `.env.example`
- Lets multiple dashboard instances be visually distinguished at a glance

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (new `dashboard-header.test.tsx` covers set / blank cases)
- [x] `npm run build`
- [x] `docker compose config`
- [ ] Manual: set `VITE_DASHBOARD_AGENT_NAME=orchid-7` in `dashboard/.env`, `docker compose up -d --build frontend`, confirm badge renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)