### PR TITLE
fix: use file-based relationship data for dashboard Now tab

### DIFF
--- a/dashboard/src/ego_dashboard/api.py
+++ b/dashboard/src/ego_dashboard/api.py
@@ -660,8 +660,15 @@ def _load_relationship_rows(settings: DashboardSettings) -> list[dict[str, objec
             continue
         trust_raw = raw.get("trust_level")
         trust_val = None
-        if isinstance(trust_raw, (int, float)) and not isinstance(trust_raw, bool):
+        if isinstance(trust_raw, bool):
+            pass
+        elif isinstance(trust_raw, (int, float)):
             trust_val = float(trust_raw)
+        elif isinstance(trust_raw, str):
+            try:
+                trust_val = float(trust_raw)
+            except ValueError:
+                pass
         total = _coerce_int(raw.get("total_interactions"), 0)
         shared_raw = raw.get("shared_episode_ids")
         shared = 0
@@ -765,9 +772,27 @@ def create_app(
             allow_headers=["*"],
         )
 
+    def _current_with_file_relationship() -> dict[str, object]:
+        result = telemetry.current()
+        rows = _load_relationship_rows(app_settings)
+        if rows:
+            best = max(
+                rows,
+                key=lambda r: (
+                    _coerce_float(r.get("trust_level"), 0),
+                    _coerce_int(r.get("shared_episodes_count"), 0),
+                ),
+            )
+            result["latest_relationship"] = {
+                "trust_level": _coerce_float(best.get("trust_level"), 0),
+                "total_interactions": float(_coerce_int(best.get("total_interactions"), 0)),
+                "shared_episodes_count": float(_coerce_int(best.get("shared_episodes_count"), 0)),
+            }
+        return result
+
     @app.get("/api/v1/current")
     def get_current() -> dict[str, object]:
-        return telemetry.current()
+        return _current_with_file_relationship()
 
     @app.get("/api/v1/usage/tools")
     def get_tool_usage(
@@ -942,7 +967,7 @@ def create_app(
                     {
                         "type": "current_snapshot",
                         "at": datetime.now(tz=UTC).isoformat(),
-                        "data": telemetry.current(),
+                        "data": _current_with_file_relationship(),
                     }
                 )
                 end = datetime.now(tz=UTC)

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -1470,3 +1470,76 @@ def test_relationship_detail_endpoint_aggregates_metrics_for_person() -> None:
     assert data["surface_counts"]["resonant"] == 1
     assert data["surface_counts"]["involuntary"] == 1
     assert data["surface_counts"]["total"] == 2
+
+
+def test_current_endpoint_uses_file_relationship_over_db(
+    tmp_path: Path,
+) -> None:
+    """The /current endpoint should prefer relationship data from the JSON file."""
+    _write_desire_catalog(tmp_path)
+    rel_dir = tmp_path / "relationships"
+    rel_dir.mkdir()
+    (rel_dir / "models.json").write_text(
+        json.dumps(
+            {
+                "alice": {
+                    "person_id": "alice",
+                    "name": "Alice",
+                    "trust_level": 0.95,
+                    "total_interactions": 726,
+                    "shared_episode_ids": ["ep_1", "ep_2", "ep_3"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    app = create_app(
+        TelemetryStore(),
+        settings=DashboardSettings(ego_mcp_data_dir=str(tmp_path)),
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/current")
+
+    assert response.status_code == 200
+    rel = response.json()["latest_relationship"]
+    assert rel is not None
+    assert rel["trust_level"] == 0.95
+    assert rel["total_interactions"] == 726.0
+    assert rel["shared_episodes_count"] == 3.0
+
+
+def test_relationships_overview_parses_string_trust_level(
+    tmp_path: Path,
+) -> None:
+    """trust_level stored as string (e.g. from legacy data) should be parsed."""
+    rel_dir = tmp_path / "relationships"
+    rel_dir.mkdir()
+    (rel_dir / "models.json").write_text(
+        json.dumps(
+            {
+                "alice": {
+                    "person_id": "alice",
+                    "name": "Alice",
+                    "trust_level": "0.85",
+                    "total_interactions": 10,
+                    "shared_episode_ids": ["ep_1"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    app = create_app(
+        TelemetryStore(),
+        settings=DashboardSettings(ego_mcp_data_dir=str(tmp_path)),
+    )
+    client = TestClient(app)
+
+    response = client.get("/api/v1/relationships/overview")
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["trust_level"] == 0.85


### PR DESCRIPTION
## Summary
- `/api/v1/current` と WebSocket (`/ws/current`) が DB テレメトリではなく relationship JSON ファイルから trust_level / shared_episodes / total_interactions を取得するように修正
- `_load_relationship_rows()` で文字列の trust_level（旧データ由来）を正しくパースするように修正
- WebSocket の `current_snapshot` が HTTP と同じロジックを使うようにして、値が一瞬だけ正しく表示されてすぐ戻る問題を解消

## Background
データディレクトリ変更時に relationship データのマージが不完全で、新しいパスにデフォルト値（trust=0.5）のファイルが作成されていた。データファイル自体は別途修正済みだが、ダッシュボードの Now タブは DB テレメトリの古い値を参照していたため反映されなかった。

## Test plan
- [x] `test_current_endpoint_uses_file_relationship_over_db` — ファイルの relationship データが current に反映される
- [x] `test_relationships_overview_parses_string_trust_level` — 文字列 trust_level が正しくパースされる
- [x] 既存テスト 121 件全通過
- [x] nyamco / mew 両方のコンテナ再ビルド・再起動で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)