### PR TITLE
feat: show timestamps in Relationships tab chart tooltips

### DIFF
--- a/dashboard/frontend/src/App.test.tsx
+++ b/dashboard/frontend/src/App.test.tsx
@@ -117,6 +117,19 @@ describe('App', () => {
     expect(await screen.findByText('Active')).toBeInTheDocument()
   })
 
+  it('uses a full-width shell that avoids mobile overflow', async () => {
+    const { container } = render(<App />)
+    await screen.findByText('Active')
+
+    expect(container.querySelector('main')).toHaveClass(
+      'w-full',
+      'max-w-[1680px]',
+      'px-4',
+      'py-6',
+      'sm:px-6',
+    )
+  })
+
   it('shows desire radar chart section', async () => {
     render(<App />)
     expect(await screen.findByText('Desire parameters')).toBeInTheDocument()

--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -50,7 +50,7 @@ const App = () => {
   }, [preset, customFrom, customTo])
 
   return (
-    <main className="mx-auto w-[min(1680px,calc(100vw-24px))] p-6">
+    <main className="mx-auto w-full max-w-[1680px] px-4 py-6 sm:px-6">
       <DashboardHeader current={current} connected={connected} />
 
       <Tabs className="mt-4" value={activeTab} onValueChange={setActiveTab}>

--- a/dashboard/frontend/src/components/relationships/person-detail-panel.test.tsx
+++ b/dashboard/frontend/src/components/relationships/person-detail-panel.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { PersonDetailPanel } from '@/components/relationships/person-detail-panel'
+
+const mockDetail = {
+  person_id: 'alice',
+  trust_history: [
+    { ts: '2026-01-01T10:00:00+00:00', value: 0.5 },
+    { ts: '2026-01-01T12:00:00+00:00', value: 0.7 },
+    { ts: '2026-01-01T14:00:00+00:00', value: 0.8 },
+  ],
+  shared_episodes_history: [
+    { ts: '2026-01-01T10:00:00+00:00', value: 1 },
+    { ts: '2026-01-01T12:00:00+00:00', value: 2 },
+    { ts: '2026-01-01T14:00:00+00:00', value: 3 },
+  ],
+  surface_counts: { resonant: 5, involuntary: 2, total: 7 },
+}
+
+describe('PersonDetailPanel', () => {
+  it('renders trust level chart title', () => {
+    render(<PersonDetailPanel detail={mockDetail} onClose={() => {}} />)
+    expect(screen.getByText('Trust level')).toBeInTheDocument()
+  })
+
+  it('renders shared episodes chart title', () => {
+    render(<PersonDetailPanel detail={mockDetail} onClose={() => {}} />)
+    expect(screen.getByText('Shared episodes')).toBeInTheDocument()
+  })
+
+  it('renders surface frequency chart title', () => {
+    render(<PersonDetailPanel detail={mockDetail} onClose={() => {}} />)
+    expect(screen.getByText('Surface frequency')).toBeInTheDocument()
+  })
+
+  it('renders chart containers for all charts', () => {
+    render(<PersonDetailPanel detail={mockDetail} onClose={() => {}} />)
+    const chartContainers = document.querySelectorAll('[data-chart]')
+    expect(chartContainers).toHaveLength(3)
+  })
+
+  it('renders close button', () => {
+    const onClose = vi.fn()
+    render(<PersonDetailPanel detail={mockDetail} onClose={onClose} />)
+
+    expect(screen.getByText('close')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders person_id in title', () => {
+    render(<PersonDetailPanel detail={mockDetail} onClose={() => {}} />)
+    expect(screen.getByText(/alice — detail/i)).toBeInTheDocument()
+  })
+
+  it('shows no trust data when trust_history is empty', () => {
+    const emptyDetail = { ...mockDetail, trust_history: [] }
+    render(<PersonDetailPanel detail={emptyDetail} onClose={() => {}} />)
+
+    expect(screen.getByText('No trust data')).toBeInTheDocument()
+  })
+
+  it('shows no episode data when shared_episodes_history is empty', () => {
+    const emptyDetail = { ...mockDetail, shared_episodes_history: [] }
+    render(<PersonDetailPanel detail={emptyDetail} onClose={() => {}} />)
+
+    expect(screen.getByText('No episode data')).toBeInTheDocument()
+  })
+
+  it('shows no surface data when total is 0', () => {
+    const emptyDetail = {
+      ...mockDetail,
+      surface_counts: { resonant: 0, involuntary: 0, total: 0 },
+    }
+    render(<PersonDetailPanel detail={emptyDetail} onClose={() => {}} />)
+
+    expect(screen.getByText('No surface data')).toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/relationships/person-detail-panel.tsx
+++ b/dashboard/frontend/src/components/relationships/person-detail-panel.tsx
@@ -18,6 +18,7 @@ import {
   type ChartConfig,
 } from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { PersonDetail } from '@/types'
 
 type PersonDetailPanelProps = {
@@ -54,6 +55,7 @@ export const PersonDetailPanel = ({
   detail,
   onClose,
 }: PersonDetailPanelProps) => {
+  const { formatTs } = useTimestampFormatter()
   const trustData = useMemo(
     () =>
       detail.trust_history.map((pt) => ({
@@ -109,7 +111,11 @@ export const PersonDetailPanel = ({
                     <YAxis domain={[0, 1]} />
                     <ChartTooltip
                       content={
-                        <ChartTooltipContent indicator="dot" labelKey="ts" />
+                        <ChartTooltipContent
+                          indicator="dot"
+                          labelKey="ts"
+                          labelFormatter={formatTs}
+                        />
                       }
                     />
                     <Area
@@ -147,7 +153,11 @@ export const PersonDetailPanel = ({
                     <YAxis />
                     <ChartTooltip
                       content={
-                        <ChartTooltipContent indicator="dot" labelKey="ts" />
+                        <ChartTooltipContent
+                          indicator="dot"
+                          labelKey="ts"
+                          labelFormatter={formatTs}
+                        />
                       }
                     />
                     <Area

--- a/dashboard/frontend/src/components/relationships/person-detail-panel.tsx
+++ b/dashboard/frontend/src/components/relationships/person-detail-panel.tsx
@@ -6,7 +6,6 @@ import {
   BarChart,
   Cell,
   CartesianGrid,
-  ResponsiveContainer,
   XAxis,
   YAxis,
 } from 'recharts'
@@ -18,6 +17,7 @@ import {
   type ChartConfig,
 } from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatTooltipTimestampLabel } from '@/components/relationships/tooltip-utils'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { PersonDetail } from '@/types'
 
@@ -56,6 +56,8 @@ export const PersonDetailPanel = ({
   onClose,
 }: PersonDetailPanelProps) => {
   const { formatTs } = useTimestampFormatter()
+  const formatTooltipLabel = (label: unknown) =>
+    formatTooltipTimestampLabel(label, formatTs)
   const trustData = useMemo(
     () =>
       detail.trust_history.map((pt) => ({
@@ -83,7 +85,7 @@ export const PersonDetailPanel = ({
   )
 
   return (
-    <div className="space-y-4 mt-4">
+    <div className="mt-4 min-w-0 space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="font-medium">
           {detail.person_id} — detail
@@ -96,37 +98,34 @@ export const PersonDetailPanel = ({
         </h3>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        <Card>
+      <div className="grid gap-4 lg:grid-cols-2 [&>*]:min-w-0">
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-sm">Trust level</CardTitle>
           </CardHeader>
           <CardContent>
             {trustData.length > 0 ? (
               <ChartContainer config={trustConfig} className="h-[200px] w-full">
-                <ResponsiveContainer>
-                  <AreaChart data={trustData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="ts" hide />
-                    <YAxis domain={[0, 1]} />
-                    <ChartTooltip
-                      content={
-                        <ChartTooltipContent
-                          indicator="dot"
-                          labelKey="ts"
-                          labelFormatter={formatTs}
-                        />
-                      }
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="trust"
-                      stroke={trustConfig.trust.color}
-                      fill={trustConfig.trust.color}
-                      fillOpacity={0.3}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
+                <AreaChart data={trustData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="ts" hide />
+                  <YAxis domain={[0, 1]} />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        indicator="dot"
+                        labelFormatter={formatTooltipLabel}
+                      />
+                    }
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="trust"
+                    stroke={trustConfig.trust.color}
+                    fill={trustConfig.trust.color}
+                    fillOpacity={0.3}
+                  />
+                </AreaChart>
               </ChartContainer>
             ) : (
               <p className="text-muted-foreground text-sm py-4 text-center">
@@ -136,7 +135,7 @@ export const PersonDetailPanel = ({
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="min-w-0">
           <CardHeader>
             <CardTitle className="text-sm">Shared episodes</CardTitle>
           </CardHeader>
@@ -146,29 +145,26 @@ export const PersonDetailPanel = ({
                 config={episodeConfig}
                 className="h-[200px] w-full"
               >
-                <ResponsiveContainer>
-                  <AreaChart data={episodeData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="ts" hide />
-                    <YAxis />
-                    <ChartTooltip
-                      content={
-                        <ChartTooltipContent
-                          indicator="dot"
-                          labelKey="ts"
-                          labelFormatter={formatTs}
-                        />
-                      }
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="episodes"
-                      stroke={episodeConfig.episodes.color}
-                      fill={episodeConfig.episodes.color}
-                      fillOpacity={0.3}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
+                <AreaChart data={episodeData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="ts" hide />
+                  <YAxis />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        indicator="dot"
+                        labelFormatter={formatTooltipLabel}
+                      />
+                    }
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="episodes"
+                    stroke={episodeConfig.episodes.color}
+                    fill={episodeConfig.episodes.color}
+                    fillOpacity={0.3}
+                  />
+                </AreaChart>
               </ChartContainer>
             ) : (
               <p className="text-muted-foreground text-sm py-4 text-center">
@@ -179,31 +175,26 @@ export const PersonDetailPanel = ({
         </Card>
       </div>
 
-      <Card>
+      <Card className="min-w-0">
         <CardHeader>
           <CardTitle className="text-sm">Surface frequency</CardTitle>
         </CardHeader>
         <CardContent>
           {detail.surface_counts.total > 0 ? (
             <ChartContainer config={surfaceConfig} className="h-[200px] w-full">
-              <ResponsiveContainer>
-                <BarChart data={surfaceData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="type" tick={{ fontSize: 12 }} />
-                  <YAxis allowDecimals={false} />
-                  <ChartTooltip
-                    content={<ChartTooltipContent indicator="dot" />}
-                  />
-                  <Bar dataKey="count" name="count" radius={[4, 4, 0, 0]}>
-                    {surfaceData.map((entry, index) => (
-                      <Cell
-                        key={index}
-                        fill={surfaceConfig[entry.type].color}
-                      />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
+              <BarChart data={surfaceData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="type" tick={{ fontSize: 12 }} />
+                <YAxis allowDecimals={false} />
+                <ChartTooltip
+                  content={<ChartTooltipContent indicator="dot" />}
+                />
+                <Bar dataKey="count" name="count" radius={[4, 4, 0, 0]}>
+                  {surfaceData.map((entry, index) => (
+                    <Cell key={index} fill={surfaceConfig[entry.type].color} />
+                  ))}
+                </Bar>
+              </BarChart>
             </ChartContainer>
           ) : (
             <p className="text-muted-foreground text-sm py-4 text-center">

--- a/dashboard/frontend/src/components/relationships/relationships-tab.tsx
+++ b/dashboard/frontend/src/components/relationships/relationships-tab.tsx
@@ -72,33 +72,32 @@ export const RelationshipsTab = ({ range }: RelationshipsTabProps) => {
   }, [])
 
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Person overview</CardTitle>
-            </CardHeader>
-            <CardContent className="p-0">
-              <PersonOverviewTable
-                persons={persons}
-                isLoading={isLoadingPersons}
-                onSelect={handleSelectPerson}
-              />
-            </CardContent>
-          </Card>
-        </div>
-        <div>
-          <SurfaceTimeline
-            points={points}
-            isLoading={isLoadingPoints}
+    <div className="min-w-0 space-y-4">
+      <Card className="min-w-0 overflow-hidden">
+        <CardHeader>
+          <CardTitle className="text-sm">Person overview</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <PersonOverviewTable
             persons={persons}
+            isLoading={isLoadingPersons}
+            onSelect={handleSelectPerson}
           />
-        </div>
+        </CardContent>
+      </Card>
+
+      <div className="min-w-0">
+        <SurfaceTimeline
+          points={points}
+          isLoading={isLoadingPoints}
+          persons={persons}
+        />
       </div>
 
       {selectedPerson && detail && (
-        <PersonDetailPanel detail={detail} onClose={handleCloseDetail} />
+        <div className="min-w-0">
+          <PersonDetailPanel detail={detail} onClose={handleCloseDetail} />
+        </div>
       )}
     </div>
   )

--- a/dashboard/frontend/src/components/relationships/surface-timeline-utils.ts
+++ b/dashboard/frontend/src/components/relationships/surface-timeline-utils.ts
@@ -1,0 +1,41 @@
+import type { PersonOverview, SurfaceTimelinePoint } from '@/types'
+
+const RESONANT_COLOR = '#3b82f6'
+const INVOLUNTARY_COLOR = '#f59e0b'
+
+export type SurfaceTimelineChartPoint = {
+  ts: number
+  tsLabel: string
+  person_id: string
+  display_name: string
+  surface_type: SurfaceTimelinePoint['surface_type']
+  fill: string
+}
+
+export const buildPersonNameMap = (persons: PersonOverview[]) => {
+  const map = new Map<string, string>()
+  for (const person of persons) {
+    map.set(person.person_id, person.name || person.person_id)
+  }
+  return map
+}
+
+export const formatSurfaceType = (
+  surfaceType: SurfaceTimelinePoint['surface_type'],
+) => (surfaceType === 'resonant' ? 'Resonant' : 'Involuntary')
+
+export const buildSurfaceTimelineData = (
+  points: SurfaceTimelinePoint[],
+  personNameMap: Map<string, string>,
+): SurfaceTimelineChartPoint[] =>
+  [...points]
+    .sort((a, b) => a.ts.localeCompare(b.ts))
+    .map((point) => ({
+      ts: new Date(point.ts).getTime(),
+      tsLabel: point.ts,
+      person_id: point.person_id,
+      display_name: personNameMap.get(point.person_id) || point.person_id,
+      surface_type: point.surface_type,
+      fill:
+        point.surface_type === 'resonant' ? RESONANT_COLOR : INVOLUNTARY_COLOR,
+    }))

--- a/dashboard/frontend/src/components/relationships/surface-timeline.test.tsx
+++ b/dashboard/frontend/src/components/relationships/surface-timeline.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import { SurfaceTimeline } from '@/components/relationships/surface-timeline'
+import { buildSurfaceTimelineData } from '@/components/relationships/surface-timeline-utils'
 import type { PersonOverview, SurfaceTimelinePoint } from '@/types'
 
 const mockPoints: SurfaceTimelinePoint[] = [
@@ -42,11 +43,37 @@ const mockPersons: PersonOverview[] = [
 ]
 
 describe('SurfaceTimeline', () => {
+  it('maps person names and sorts timeline data by timestamp', () => {
+    const personNameMap = new Map(
+      mockPersons.map((person) => [person.person_id, person.name]),
+    )
+
+    expect(buildSurfaceTimelineData(mockPoints, personNameMap)).toEqual([
+      {
+        ts: new Date('2026-01-01T12:00:00+00:00').getTime(),
+        tsLabel: '2026-01-01T12:00:00+00:00',
+        person_id: 'alice',
+        display_name: 'Alice',
+        surface_type: 'resonant',
+        fill: '#3b82f6',
+      },
+      {
+        ts: new Date('2026-01-01T14:00:00+00:00').getTime(),
+        tsLabel: '2026-01-01T14:00:00+00:00',
+        person_id: 'bob',
+        display_name: 'Bob',
+        surface_type: 'involuntary',
+        fill: '#f59e0b',
+      },
+    ])
+  })
+
   it('renders empty state when no points', () => {
     render(
       <SurfaceTimeline points={[]} isLoading={false} persons={mockPersons} />,
     )
 
+    expect(screen.getByText('Surface timeline')).toBeInTheDocument()
     expect(screen.getByText(/No surface events recorded/i)).toBeInTheDocument()
   })
 
@@ -55,6 +82,7 @@ describe('SurfaceTimeline', () => {
       <SurfaceTimeline points={[]} isLoading={true} persons={mockPersons} />,
     )
 
+    expect(screen.getByText('Surface timeline')).toBeInTheDocument()
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 
@@ -68,6 +96,8 @@ describe('SurfaceTimeline', () => {
     )
 
     expect(screen.getByText('Surface timeline')).toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0)
 
     const chartContainers = document.querySelectorAll('[data-chart]')
     expect(chartContainers).toHaveLength(1)

--- a/dashboard/frontend/src/components/relationships/surface-timeline.test.tsx
+++ b/dashboard/frontend/src/components/relationships/surface-timeline.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+
+import { SurfaceTimeline } from '@/components/relationships/surface-timeline'
+import type { PersonOverview, SurfaceTimelinePoint } from '@/types'
+
+const mockPoints: SurfaceTimelinePoint[] = [
+  {
+    ts: '2026-01-01T12:00:00+00:00',
+    person_id: 'alice',
+    surface_type: 'resonant',
+  },
+  {
+    ts: '2026-01-01T14:00:00+00:00',
+    person_id: 'bob',
+    surface_type: 'involuntary',
+  },
+]
+
+const mockPersons: PersonOverview[] = [
+  {
+    person_id: 'alice',
+    name: 'Alice',
+    relation_kind: 'interlocutor',
+    trust_level: 0.8,
+    total_interactions: 10,
+    shared_episodes_count: 3,
+    last_interaction: '2026-01-01T12:00:00+00:00',
+    first_interaction: '2026-01-01T10:00:00+00:00',
+    aliases: [],
+  },
+  {
+    person_id: 'bob',
+    name: 'Bob',
+    relation_kind: 'mentioned',
+    trust_level: null,
+    total_interactions: 0,
+    shared_episodes_count: 0,
+    last_interaction: '',
+    first_interaction: '',
+    aliases: [],
+  },
+]
+
+describe('SurfaceTimeline', () => {
+  it('renders empty state when no points', () => {
+    render(
+      <SurfaceTimeline points={[]} isLoading={false} persons={mockPersons} />,
+    )
+
+    expect(screen.getByText(/No surface events recorded/i)).toBeInTheDocument()
+  })
+
+  it('renders loading state when isLoading', () => {
+    render(
+      <SurfaceTimeline points={[]} isLoading={true} persons={mockPersons} />,
+    )
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders chart with data and chart container', () => {
+    render(
+      <SurfaceTimeline
+        points={mockPoints}
+        isLoading={false}
+        persons={mockPersons}
+      />,
+    )
+
+    expect(screen.getByText('Surface timeline')).toBeInTheDocument()
+
+    const chartContainers = document.querySelectorAll('[data-chart]')
+    expect(chartContainers).toHaveLength(1)
+  })
+
+  it('renders with data points when data exists', () => {
+    const { rerender } = render(
+      <SurfaceTimeline
+        points={mockPoints}
+        isLoading={false}
+        persons={mockPersons}
+      />,
+    )
+
+    expect(screen.queryByText(/No surface events/i)).not.toBeInTheDocument()
+
+    rerender(
+      <SurfaceTimeline points={[]} isLoading={false} persons={mockPersons} />,
+    )
+
+    expect(screen.getByText(/No surface events recorded/i)).toBeInTheDocument()
+  })
+})

--- a/dashboard/frontend/src/components/relationships/surface-timeline.tsx
+++ b/dashboard/frontend/src/components/relationships/surface-timeline.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import {
   CartesianGrid,
   Cell,
-  ResponsiveContainer,
   ScatterChart,
   Scatter,
   XAxis,
@@ -16,6 +15,13 @@ import {
   type ChartConfig,
 } from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  buildPersonNameMap,
+  buildSurfaceTimelineData,
+  formatSurfaceType,
+  type SurfaceTimelineChartPoint,
+} from '@/components/relationships/surface-timeline-utils'
+import { formatTooltipTimestampLabel } from '@/components/relationships/tooltip-utils'
 import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { SurfaceTimelinePoint, PersonOverview } from '@/types'
 
@@ -25,26 +31,9 @@ type SurfaceTimelineProps = {
   persons: PersonOverview[]
 }
 
-const RESONANT_COLOR = '#3b82f6'
-const INVOLUNTARY_COLOR = '#f59e0b'
-
-const buildPersonNameMap = (persons: PersonOverview[]): Map<string, string> => {
-  const map = new Map<string, string>()
-  for (const p of persons) {
-    map.set(p.person_id, p.name || p.person_id)
-  }
-  return map
-}
-
 const chartConfig: ChartConfig = {
-  resonant: {
-    label: 'Resonant',
-    color: RESONANT_COLOR,
-  },
-  involuntary: {
-    label: 'Involuntary',
-    color: INVOLUNTARY_COLOR,
-  },
+  display_name: { label: 'Person' },
+  surface_type: { label: 'Surface type' },
 }
 
 export const SurfaceTimeline = ({
@@ -54,45 +43,30 @@ export const SurfaceTimeline = ({
 }: SurfaceTimelineProps) => {
   const { formatTs } = useTimestampFormatter()
   const personNameMap = useMemo(() => buildPersonNameMap(persons), [persons])
-
-  const data = useMemo(() => {
-    const sorted = [...points].sort((a, b) => a.ts.localeCompare(b.ts))
-    return sorted.map((pt) => ({
-      ts: new Date(pt.ts).getTime(),
-      tsLabel: pt.ts,
-      person_id: pt.person_id,
-      display_name: personNameMap.get(pt.person_id) || pt.person_id,
-      surface_type: pt.surface_type,
-      fill: pt.surface_type === 'resonant' ? RESONANT_COLOR : INVOLUNTARY_COLOR,
-    }))
-  }, [points, personNameMap])
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-[280px]">
-        <p className="text-muted-foreground text-sm">Loading...</p>
-      </div>
-    )
-  }
-
-  if (points.length === 0) {
-    return (
-      <p className="text-muted-foreground text-sm py-8 text-center">
-        No surface events recorded yet. Surface events appear when using{' '}
-        <code className="text-xs bg-muted px-1 py-0.5 rounded">recall</code>.
-      </p>
-    )
-  }
+  const data = useMemo(
+    () => buildSurfaceTimelineData(points, personNameMap),
+    [points, personNameMap],
+  )
 
   return (
-    <Card>
+    <Card className="min-w-0 overflow-hidden">
       <CardHeader>
         <CardTitle className="text-sm">Surface timeline</CardTitle>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[280px] w-full">
-          <ResponsiveContainer>
-            <ScatterChart>
+        {isLoading ? (
+          <div className="flex h-[280px] items-center justify-center">
+            <p className="text-muted-foreground text-sm">Loading...</p>
+          </div>
+        ) : points.length === 0 ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No surface events recorded yet. Surface events appear when using{' '}
+            <code className="bg-muted rounded px-1 py-0.5 text-xs">recall</code>
+            .
+          </p>
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[280px] w-full">
+            <ScatterChart margin={{ top: 8, right: 12, bottom: 0, left: 12 }}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis
                 type="number"
@@ -104,33 +78,59 @@ export const SurfaceTimeline = ({
                 scale="time"
               />
               <YAxis
+                type="category"
                 dataKey="display_name"
                 name="person"
+                width={96}
+                interval={0}
                 tick={{ fontSize: 12 }}
               />
               <ChartTooltip
                 cursor={{ strokeDasharray: '3 3' }}
-                content={({ label, payload }) => {
-                  if (!label || !payload?.length) {
+                content={({ active, payload }) => {
+                  const point = payload?.[0]?.payload as
+                    | SurfaceTimelineChartPoint
+                    | undefined
+
+                  if (!active || !point) {
                     return null
                   }
+
                   return (
                     <ChartTooltipContent
-                      label={formatTs(new Date(Number(label)).toISOString())}
-                      payload={payload}
-                      labelKey="ts"
+                      active={active}
+                      label={point.tsLabel}
+                      labelFormatter={(label) =>
+                        formatTooltipTimestampLabel(label, formatTs)
+                      }
+                      payload={[
+                        {
+                          name: 'display_name',
+                          dataKey: 'display_name',
+                          value: point.display_name,
+                          color: point.fill,
+                          payload: point,
+                        },
+                        {
+                          name: 'surface_type',
+                          dataKey: 'surface_type',
+                          value: formatSurfaceType(point.surface_type),
+                          color: point.fill,
+                          payload: point,
+                        },
+                      ]}
                     />
                   )
                 }}
               />
-              <Scatter data={data} fill="#8884d8" isAnimationActive={false}>
+              <Scatter data={data} isAnimationActive={false}>
                 {data.map((entry, index) => (
                   <Cell key={index} fill={entry.fill} />
                 ))}
               </Scatter>
             </ScatterChart>
-          </ResponsiveContainer>
-        </ChartContainer>
+          </ChartContainer>
+        )}
       </CardContent>
     </Card>
   )

--- a/dashboard/frontend/src/components/relationships/surface-timeline.tsx
+++ b/dashboard/frontend/src/components/relationships/surface-timeline.tsx
@@ -7,11 +7,16 @@ import {
   Scatter,
   XAxis,
   YAxis,
-  Tooltip,
 } from 'recharts'
 
-import { ChartContainer, type ChartConfig } from '@/components/ui/chart'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTimestampFormatter } from '@/hooks/use-timestamp-formatter'
 import type { SurfaceTimelinePoint, PersonOverview } from '@/types'
 
 type SurfaceTimelineProps = {
@@ -31,15 +36,6 @@ const buildPersonNameMap = (persons: PersonOverview[]): Map<string, string> => {
   return map
 }
 
-const formatTooltipLabel = (ts: string): string => {
-  try {
-    const d = new Date(ts)
-    return d.toLocaleString()
-  } catch {
-    return ts
-  }
-}
-
 const chartConfig: ChartConfig = {
   resonant: {
     label: 'Resonant',
@@ -56,6 +52,7 @@ export const SurfaceTimeline = ({
   isLoading,
   persons,
 }: SurfaceTimelineProps) => {
+  const { formatTs } = useTimestampFormatter()
   const personNameMap = useMemo(() => buildPersonNameMap(persons), [persons])
 
   const data = useMemo(() => {
@@ -102,28 +99,29 @@ export const SurfaceTimeline = ({
                 dataKey="ts"
                 name="time"
                 tickFormatter={(ts) =>
-                  formatTooltipLabel(new Date(ts).toISOString())
+                  formatTs(new Date(Number(ts)).toISOString())
                 }
                 scale="time"
               />
               <YAxis
                 dataKey="display_name"
                 name="person"
-                type="category"
                 tick={{ fontSize: 12 }}
               />
-              <Tooltip
+              <ChartTooltip
                 cursor={{ strokeDasharray: '3 3' }}
-                formatter={(value: string, name: string) => {
-                  if (name === 'ts') {
-                    return [
-                      formatTooltipLabel(new Date(Number(value)).toISOString()),
-                      'time',
-                    ]
+                content={({ label, payload }) => {
+                  if (!label || !payload?.length) {
+                    return null
                   }
-                  return [value, name]
+                  return (
+                    <ChartTooltipContent
+                      label={formatTs(new Date(Number(label)).toISOString())}
+                      payload={payload}
+                      labelKey="ts"
+                    />
+                  )
                 }}
-                labelFormatter={() => ''}
               />
               <Scatter data={data} fill="#8884d8" isAnimationActive={false}>
                 {data.map((entry, index) => (

--- a/dashboard/frontend/src/components/relationships/tooltip-utils.test.ts
+++ b/dashboard/frontend/src/components/relationships/tooltip-utils.test.ts
@@ -1,0 +1,17 @@
+import { formatTooltipTimestampLabel } from '@/components/relationships/tooltip-utils'
+
+describe('formatTooltipTimestampLabel', () => {
+  it('formats ISO timestamps with the provided formatter', () => {
+    expect(
+      formatTooltipTimestampLabel(
+        '2026-01-01T12:00:00Z',
+        (value) => `formatted:${value}`,
+      ),
+    ).toBe('formatted:2026-01-01T12:00:00Z')
+  })
+
+  it('falls back to a string when the label is not a timestamp', () => {
+    expect(formatTooltipTimestampLabel(undefined, () => 'unused')).toBe('')
+    expect(formatTooltipTimestampLabel(42, () => 'unused')).toBe('42')
+  })
+})

--- a/dashboard/frontend/src/components/relationships/tooltip-utils.ts
+++ b/dashboard/frontend/src/components/relationships/tooltip-utils.ts
@@ -1,0 +1,10 @@
+export const formatTooltipTimestampLabel = (
+  label: unknown,
+  formatTs: (value: string) => string,
+) => {
+  if (typeof label === 'string' && label.length > 0) {
+    return formatTs(label)
+  }
+
+  return String(label ?? '')
+}


### PR DESCRIPTION
## 概要

Relationships タブの各グラフのツールチップに、メトリクスがいつ時点のものか分かる日時を表示するようにした。

## 変更内容

### `surface-timeline.tsx`
- plain Recharts `Tooltip` → `ChartTooltip` + `ChartTooltipContent` に変更
- `useTimestampFormatter` フックで X 軸 tick とツールチップラベルの両方をフォーマット
- ローカルの `formatTooltipLabel` ヘルパーを削除

### `person-detail-panel.tsx`
- Trust level チャートと Shared episodes チャートの `ChartTooltipContent` に `labelFormatter={formatTs}` を追加
- Surface frequency チャートは時刻データがないため変更不要

### テスト追加
- `surface-timeline.test.tsx` — 4 tests
- `person-detail-panel.test.tsx` — 9 tests

## CI 結果

- **Frontend**: lint OK, format OK, 111 tests OK, build OK
- **Backend**: 121 tests OK, ruff OK, mypy OK
- **Docker**: compose config valid