### PR TITLE
fix: notion meta fields review P1/P2 follow-ups

### DIFF
--- a/dashboard/frontend/src/components/memory/memory-graph-legend.tsx
+++ b/dashboard/frontend/src/components/memory/memory-graph-legend.tsx
@@ -189,6 +189,11 @@ export const MemoryGraphLegend = ({
             color={getEdgeStroke('notion_related')}
             dashArray="6 4"
           />
+          <EdgeSwatch
+            label="Meta link"
+            color={getEdgeStroke('meta_notion_link')}
+            dashArray="5 3"
+          />
         </div>
       </CardContent>
     </Card>

--- a/dashboard/frontend/src/components/memory/memory-graph-palette.ts
+++ b/dashboard/frontend/src/components/memory/memory-graph-palette.ts
@@ -106,6 +106,8 @@ export const getEdgeStroke = (linkType: string) => {
       return 'hsl(270, 60%, 55%)'
     case 'notion_related':
       return 'hsl(45, 90%, 50%)'
+    case 'meta_notion_link':
+      return 'hsl(320, 60%, 55%)'
     default:
       return 'hsl(0, 0%, 60%)'
   }
@@ -117,6 +119,8 @@ export const getEdgeDashArray = (linkType: string) => {
       return '4 4'
     case 'notion_related':
       return '6 4'
+    case 'meta_notion_link':
+      return '5 3'
     default:
       return undefined
   }
@@ -140,6 +144,8 @@ export const getEdgeStrokeWidth = (
       return 2 + emphasis
     case 'notion_related':
       return confidence * 3 + 1 + emphasis
+    case 'meta_notion_link':
+      return 2 + emphasis
     default:
       return Math.max(1.5, confidence * 3) + emphasis
   }

--- a/dashboard/frontend/src/components/memory/memory-tab.test.tsx
+++ b/dashboard/frontend/src/components/memory/memory-tab.test.tsx
@@ -131,4 +131,38 @@ describe('MemoryTab', () => {
     expect(await screen.findByText('Memory detail')).toBeInTheDocument()
     expect(screen.getByText('Detailed memory body')).toBeInTheDocument()
   })
+
+  it('renders related notions section with correct IDs', async () => {
+    const { render, screen } = await import('@testing-library/react')
+    const { NotionDetailPanel } =
+      await import('@/components/memory/notion-detail-panel')
+
+    const notionNode = {
+      id: 'notion-1',
+      label: 'Memory systems',
+      category: 'notion',
+      is_notion: true,
+      confidence: 0.91,
+      reinforcement_count: 6,
+      source_count: 1,
+      degree: 2,
+      betweenness: 0.2,
+      is_conviction: true,
+      meta_fields: {},
+    } satisfies Partial<MemoryNetworkResponse['nodes'][number]> & {
+      is_notion: true
+    } as MemoryNetworkResponse['nodes'][number]
+
+    render(
+      <NotionDetailPanel
+        notion={notionNode}
+        relatedNotionIds={['notion-2']}
+        sourceMemoryIds={['mem-1']}
+        onNotionClick={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Related notions/)).toBeInTheDocument()
+    expect(screen.getByText(/notion-2/)).toBeInTheDocument()
+  })
 })

--- a/dashboard/frontend/src/components/memory/memory-tab.tsx
+++ b/dashboard/frontend/src/components/memory/memory-tab.tsx
@@ -142,6 +142,7 @@ export const MemoryTab = ({ isActive = true }: MemoryTabProps) => {
     if (!selectedNode?.is_notion) return []
     const related = new Set<string>()
     for (const edge of baseNetwork.edges) {
+      if (edge.link_type !== 'notion_related') continue
       if (edge.source === selectedNode.id) {
         const target = baseNetwork.nodes.find((node) => node.id === edge.target)
         if (target?.is_notion) related.add(target.id)
@@ -306,6 +307,14 @@ export const MemoryTab = ({ isActive = true }: MemoryTabProps) => {
                 notion={selectedNode}
                 relatedNotionIds={relatedNotionIds}
                 sourceMemoryIds={sourceMemoryIds}
+                onNotionClick={(notionId) => {
+                  const notionNode = baseNetwork.nodes.find(
+                    (n) => n.id === notionId,
+                  )
+                  if (notionNode) {
+                    setSelectedNode(notionNode)
+                  }
+                }}
               />
             ) : selectedDetail ? (
               <MemoryDetailPanel detail={selectedDetail} />

--- a/dashboard/frontend/src/components/memory/notion-detail-panel.tsx
+++ b/dashboard/frontend/src/components/memory/notion-detail-panel.tsx
@@ -22,6 +22,17 @@ const MetaFieldDisplay = ({
   field: MetaField
   onNotionClick?: (notionId: string) => void
 }) => {
+  if (!field || typeof field !== 'object' || typeof field.type !== 'string') {
+    return (
+      <div className="rounded-md border bg-muted/10 px-3 py-2">
+        <span className="text-muted-foreground font-medium">{fieldKey}:</span>
+        <span className="ml-2 text-red-400 text-xs">
+          (malformed meta_field)
+        </span>
+      </div>
+    )
+  }
+
   if (field.type === 'text') {
     return (
       <div className="rounded-md border bg-muted/10 px-3 py-2">

--- a/dashboard/frontend/src/components/memory/notion-detail-panel.tsx
+++ b/dashboard/frontend/src/components/memory/notion-detail-panel.tsx
@@ -4,12 +4,62 @@ import { fetchNotionHistory } from '@/api'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { notionToneGroup } from '@/components/memory/memory-graph-palette'
-import type { MemoryNetworkNode, SeriesPoint } from '@/types'
+import type { MemoryNetworkNode, MetaField, SeriesPoint } from '@/types'
 
 type NotionDetailPanelProps = {
   notion: MemoryNetworkNode
   relatedNotionIds: string[]
   sourceMemoryIds: string[]
+  onNotionClick?: (notionId: string) => void
+}
+
+const MetaFieldDisplay = ({
+  fieldKey,
+  field,
+  onNotionClick,
+}: {
+  fieldKey: string
+  field: MetaField
+  onNotionClick?: (notionId: string) => void
+}) => {
+  if (field.type === 'text') {
+    return (
+      <div className="rounded-md border bg-muted/10 px-3 py-2">
+        <span className="text-muted-foreground font-medium">{fieldKey}:</span>
+        <span className="ml-2">{field.value}</span>
+      </div>
+    )
+  }
+
+  if (field.type === 'file_path') {
+    return (
+      <div className="rounded-md border bg-muted/10 px-3 py-2">
+        <span className="text-muted-foreground font-medium">{fieldKey}:</span>
+        <span className="ml-2 font-mono text-xs">{field.path}</span>
+      </div>
+    )
+  }
+
+  if (field.type === 'notion_ids') {
+    return (
+      <div className="rounded-md border bg-muted/10 px-3 py-2">
+        <span className="text-muted-foreground font-medium">{fieldKey}:</span>
+        <div className="mt-1 flex flex-wrap gap-1">
+          {field.notion_ids.map((id) => (
+            <button
+              key={id}
+              onClick={() => onNotionClick?.(id)}
+              className="rounded bg-amber-500/20 px-2 py-0.5 text-xs text-amber-300 hover:bg-amber-500/30 transition-colors cursor-pointer"
+            >
+              {id}
+            </button>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return null
 }
 
 const formatTimestamp = (value?: string | null) =>
@@ -36,6 +86,7 @@ export const NotionDetailPanel = ({
   notion,
   relatedNotionIds,
   sourceMemoryIds,
+  onNotionClick,
 }: NotionDetailPanelProps) => {
   const [history, setHistory] = useState<SeriesPoint[]>([])
 
@@ -134,6 +185,31 @@ export const NotionDetailPanel = ({
             </Badge>
           ))}
         </div>
+
+        {(() => {
+          const metaFields = notion.meta_fields ?? {}
+          const metaFieldEntries = Object.entries(metaFields)
+          if (metaFieldEntries.length === 0) {
+            return null
+          }
+          return (
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                Meta fields ({metaFieldEntries.length})
+              </p>
+              <div className="space-y-2 text-xs">
+                {metaFieldEntries.map(([key, field]) => (
+                  <MetaFieldDisplay
+                    key={key}
+                    fieldKey={key}
+                    field={field}
+                    onNotionClick={onNotionClick}
+                  />
+                ))}
+              </div>
+            </div>
+          )
+        })()}
 
         <div className="space-y-2">
           <p className="text-muted-foreground text-xs uppercase tracking-wide">

--- a/dashboard/frontend/src/types.ts
+++ b/dashboard/frontend/src/types.ts
@@ -71,6 +71,23 @@ export type HistoryMarker = {
   memory_id?: string
   desire_key?: string
 }
+export type TextMetaField = {
+  type: 'text'
+  value: string
+}
+
+export type FilePathMetaField = {
+  type: 'file_path'
+  path: string
+}
+
+export type NotionIdsMetaField = {
+  type: 'notion_ids'
+  notion_ids: string[]
+}
+
+export type MetaField = TextMetaField | FilePathMetaField | NotionIdsMetaField
+
 export type MemoryNetworkNode = {
   id: string
   label?: string
@@ -96,6 +113,7 @@ export type MemoryNetworkNode = {
   last_accessed?: string | null
   created?: string | null
   last_reinforced?: string | null
+  meta_fields?: Record<string, MetaField>
 }
 export type MemoryNetworkEdge = {
   source: string
@@ -175,6 +193,7 @@ export type Notion = {
   is_conviction: boolean
   created: string
   last_reinforced: string
+  meta_fields?: Record<string, MetaField>
 }
 export type LogPoint = {
   ts: string

--- a/dashboard/src/ego_dashboard/api.py
+++ b/dashboard/src/ego_dashboard/api.py
@@ -253,6 +253,9 @@ def _load_notion_rows(settings: DashboardSettings) -> list[dict[str, object]]:
         reinforcement_count = _coerce_int(raw.get("reinforcement_count"), 0)
         person_id = raw.get("person_id")
         confidence = float(raw.get("confidence", 0.5))
+        meta_fields = raw.get("meta_fields", {})
+        if not isinstance(meta_fields, dict):
+            meta_fields = {}
         rows.append(
             {
                 "id": str(notion_id),
@@ -269,6 +272,7 @@ def _load_notion_rows(settings: DashboardSettings) -> list[dict[str, object]]:
                 "created": str(raw.get("created", "")),
                 "last_reinforced": str(raw.get("last_reinforced", "")),
                 "tags": _coerce_tags(raw.get("tags", [])),
+                "meta_fields": meta_fields,
             }
         )
     rows.sort(key=lambda row: str(row.get("created", "")), reverse=True)
@@ -443,6 +447,33 @@ def _build_network_edges(
                     "confidence": _clamp_float(notion.get("confidence"), 0.5),
                 }
             )
+
+        # Add edges from meta_fields notion_ids
+        meta_fields = notion.get("meta_fields", {})
+        if not isinstance(meta_fields, dict):
+            continue
+        for key, meta_field in meta_fields.items():
+            if not isinstance(meta_field, dict):
+                continue
+            if meta_field.get("type") != "notion_ids":
+                continue
+            for target_id in meta_field.get("notion_ids", []):
+                if not isinstance(target_id, str):
+                    continue
+                if target_id not in node_ids or notion_id not in node_ids:
+                    continue
+                edge_key = _edge_identity(notion_id, target_id, "meta_notion_link")
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
+                edges.append(
+                    {
+                        "source": notion_id,
+                        "target": target_id,
+                        "link_type": "meta_notion_link",
+                        "confidence": _clamp_float(notion.get("confidence"), 0.5),
+                    }
+                )
     return edges
 
 
@@ -591,6 +622,7 @@ def _build_memory_network(
                 "last_accessed": None,
                 "created": notion.get("created") or None,
                 "last_reinforced": notion.get("last_reinforced") or None,
+                "meta_fields": notion.get("meta_fields"),
             }
         )
 

--- a/dashboard/src/ego_dashboard/api.py
+++ b/dashboard/src/ego_dashboard/api.py
@@ -224,6 +224,34 @@ def _load_link_metadata(value: object) -> list[_MemoryLinkPayload]:
     return links
 
 
+def _is_valid_meta_field(value: object) -> bool:
+    """Check whether a meta_field entry matches the expected union shape."""
+    if not isinstance(value, dict):
+        return False
+    field_type = value.get("type")
+    if field_type not in ("text", "file_path", "notion_ids"):
+        return False
+    if field_type == "text":
+        return isinstance(value.get("value"), str)
+    if field_type == "file_path":
+        return isinstance(value.get("path"), str)
+    if field_type == "notion_ids":
+        ids = value.get("notion_ids")
+        return isinstance(ids, list) and all(isinstance(i, str) for i in ids)
+    return False
+
+
+def _sanitize_meta_fields(raw: dict[str, object]) -> dict[str, object]:
+    """Filter out malformed meta_field entries."""
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        key: value
+        for key, value in raw.items()
+        if isinstance(key, str) and _is_valid_meta_field(value)
+    }
+
+
 def _load_notion_rows(settings: DashboardSettings) -> list[dict[str, object]]:
     if not settings.ego_mcp_data_dir:
         return []
@@ -253,9 +281,7 @@ def _load_notion_rows(settings: DashboardSettings) -> list[dict[str, object]]:
         reinforcement_count = _coerce_int(raw.get("reinforcement_count"), 0)
         person_id = raw.get("person_id")
         confidence = float(raw.get("confidence", 0.5))
-        meta_fields = raw.get("meta_fields", {})
-        if not isinstance(meta_fields, dict):
-            meta_fields = {}
+        meta_fields = _sanitize_meta_fields(raw.get("meta_fields", {}))
         rows.append(
             {
                 "id": str(notion_id),
@@ -459,6 +485,8 @@ def _build_network_edges(
                 continue
             for target_id in meta_field.get("notion_ids", []):
                 if not isinstance(target_id, str):
+                    continue
+                if target_id == notion_id:
                     continue
                 if target_id not in node_ids or notion_id not in node_ids:
                     continue

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -1627,3 +1627,129 @@ def test_build_network_edges_creates_meta_notion_link_edges(
     assert len(meta_links) == 1
     assert meta_links[0]["source"] == "n1"
     assert meta_links[0]["target"] == "n2"
+
+
+def test_build_network_edges_skips_self_referential_notion_ids(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "notions.json").write_text(
+        json.dumps(
+            {
+                "n1": {
+                    "label": "self ref",
+                    "emotion_tone": "curious",
+                    "confidence": 0.8,
+                    "source_memory_ids": ["m1"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 6,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                    "meta_fields": {
+                        "self_ref": {"type": "notion_ids", "notion_ids": ["n1"]},
+                        "other": {"type": "notion_ids", "notion_ids": ["n2"]},
+                    },
+                },
+                "n2": {
+                    "label": "other",
+                    "emotion_tone": "curious",
+                    "confidence": 0.7,
+                    "source_memory_ids": ["m2"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 3,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _load_memory_network(DashboardSettings(ego_mcp_data_dir=str(tmp_path)))
+
+    edges: list[dict[str, object]] = result["edges"]  # type: ignore[assignment]
+    meta_links = [e for e in edges if e.get("link_type") == "meta_notion_link"]
+    assert len(meta_links) == 1
+    assert meta_links[0]["source"] == "n1"
+    assert meta_links[0]["target"] == "n2"
+
+
+def test_load_memory_network_sanitizes_malformed_meta_fields(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "notions.json").write_text(
+        json.dumps(
+            {
+                "n1": {
+                    "label": "sanitized notion",
+                    "emotion_tone": "curious",
+                    "confidence": 0.8,
+                    "source_memory_ids": ["m1"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 6,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                    "meta_fields": {
+                        "good_text": {"type": "text", "value": "hello"},
+                        "bad_null": None,
+                        "bad_missing_type": {"value": "no type"},
+                        "bad_type": {"type": "unknown_type", "value": "x"},
+                        "good_ids": {"type": "notion_ids", "notion_ids": ["n2"]},
+                        "bad_ids": {"type": "notion_ids", "notion_ids": "not an array"},
+                    },
+                },
+                "n2": {
+                    "label": "target",
+                    "emotion_tone": "curious",
+                    "confidence": 0.7,
+                    "source_memory_ids": ["m2"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 3,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _load_memory_network(DashboardSettings(ego_mcp_data_dir=str(tmp_path)))
+
+    nodes: list[dict[str, object]] = result["nodes"]  # type: ignore[assignment]
+    notion_nodes = [n for n in nodes if n.get("is_notion") and n.get("id") == "n1"]
+    assert len(notion_nodes) == 1
+    node = notion_nodes[0]
+    meta = node["meta_fields"]
+    assert isinstance(meta, dict)
+    assert "good_text" in meta
+    assert meta["good_text"] == {"type": "text", "value": "hello"}
+    assert "good_ids" in meta
+    assert meta["good_ids"] == {"type": "notion_ids", "notion_ids": ["n2"]}
+    assert "bad_null" not in meta
+    assert "bad_missing_type" not in meta
+    assert "bad_type" not in meta
+    assert "bad_ids" not in meta
+
+
+def test_is_valid_meta_field_accepts_valid_entries() -> None:
+    from ego_dashboard.api import _is_valid_meta_field
+
+    assert _is_valid_meta_field({"type": "text", "value": "hello"}) is True
+    assert _is_valid_meta_field({"type": "file_path", "path": "/a/b"}) is True
+    assert _is_valid_meta_field({"type": "notion_ids", "notion_ids": ["n1"]}) is True
+
+
+def test_is_valid_meta_field_rejects_invalid_entries() -> None:
+    from ego_dashboard.api import _is_valid_meta_field
+
+    assert _is_valid_meta_field(None) is False
+    assert _is_valid_meta_field("string") is False
+    assert _is_valid_meta_field([]) is False
+    assert _is_valid_meta_field({"type": "unknown"}) is False
+    assert _is_valid_meta_field({"type": "text"}) is False
+    assert _is_valid_meta_field({"type": "file_path"}) is False
+    assert _is_valid_meta_field({"type": "notion_ids", "notion_ids": "not_array"}) is False
+    assert _is_valid_meta_field({"type": "notion_ids", "notion_ids": [123]}) is False

--- a/dashboard/tests/test_api.py
+++ b/dashboard/tests/test_api.py
@@ -679,6 +679,7 @@ def test_load_memory_network_keeps_notion_nodes_when_memory_load_fails(
             "last_accessed": None,
             "created": "2026-01-01T12:00:00+00:00",
             "last_reinforced": "2026-01-02T12:00:00+00:00",
+            "meta_fields": {},
         }
     ]
     assert result["edges"] == []
@@ -1543,3 +1544,86 @@ def test_relationships_overview_parses_string_trust_level(
     items = response.json()["items"]
     assert len(items) == 1
     assert items[0]["trust_level"] == 0.85
+
+
+def test_load_memory_network_carries_meta_fields_to_nodes(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "notions.json").write_text(
+        json.dumps(
+            {
+                "n1": {
+                    "label": "notion with meta",
+                    "emotion_tone": "curious",
+                    "confidence": 0.8,
+                    "source_memory_ids": ["m1"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 6,
+                    "person_id": "Master",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                    "meta_fields": {
+                        "note": {"type": "text", "value": "hello"},
+                        "ids": {"type": "notion_ids", "notion_ids": ["n1"]},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _load_memory_network(DashboardSettings(ego_mcp_data_dir=str(tmp_path)))
+
+    nodes: list[dict[str, object]] = result["nodes"]  # type: ignore[assignment]
+    notion_nodes = [n for n in nodes if n.get("is_notion")]
+    assert len(notion_nodes) == 1
+    node = notion_nodes[0]
+    assert node["meta_fields"] == {
+        "note": {"type": "text", "value": "hello"},
+        "ids": {"type": "notion_ids", "notion_ids": ["n1"]},
+    }
+
+
+def test_build_network_edges_creates_meta_notion_link_edges(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "notions.json").write_text(
+        json.dumps(
+            {
+                "n1": {
+                    "label": "source",
+                    "emotion_tone": "curious",
+                    "confidence": 0.8,
+                    "source_memory_ids": ["m1"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 6,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                    "meta_fields": {
+                        "linked": {"type": "notion_ids", "notion_ids": ["n2"]},
+                    },
+                },
+                "n2": {
+                    "label": "target",
+                    "emotion_tone": "curious",
+                    "confidence": 0.7,
+                    "source_memory_ids": ["m2"],
+                    "related_notion_ids": [],
+                    "reinforcement_count": 3,
+                    "person_id": "",
+                    "created": "2026-01-01T12:00:00+00:00",
+                    "last_reinforced": "2026-01-02T12:00:00+00:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _load_memory_network(DashboardSettings(ego_mcp_data_dir=str(tmp_path)))
+
+    edges: list[dict[str, object]] = result["edges"]  # type: ignore[assignment]
+    meta_links = [e for e in edges if e.get("link_type") == "meta_notion_link"]
+    assert len(meta_links) == 1
+    assert meta_links[0]["source"] == "n1"
+    assert meta_links[0]["target"] == "n2"

--- a/ego-mcp/pyproject.toml
+++ b/ego-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ego-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "Cognitive scaffolding MCP server for LLM personality continuity"
 requires-python = ">=3.14"
 dependencies = [

--- a/ego-mcp/src/ego_mcp/__init__.py
+++ b/ego-mcp/src/ego_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ego-mcp: Cognitive scaffolding MCP server."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/ego-mcp/src/ego_mcp/_server_backend_handlers.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_handlers.py
@@ -25,7 +25,9 @@ from ego_mcp.consolidation import ConsolidationEngine
 from ego_mcp.episode import EpisodeStore
 from ego_mcp.memory import MemoryStore
 from ego_mcp.notion import (
+    DeadLink,
     NotionStore,
+    find_dead_links,
     generate_notion_from_cluster,
     infer_person_id,
     is_ephemeral_cluster,
@@ -35,6 +37,7 @@ from ego_mcp.scaffolds import (
     compose_response,
 )
 from ego_mcp.self_model import SelfModelStore
+from ego_mcp.types import MetaField
 
 logger = logging.getLogger(__name__)
 _relative_time_override: Callable[[str, datetime | None], str] | None = None
@@ -118,7 +121,9 @@ def _load_person_memory_ids(memory: MemoryStore) -> dict[str, set[str]]:
 
 
 async def _handle_consolidate(
-    memory: MemoryStore, consolidation: ConsolidationEngine
+    memory: MemoryStore,
+    consolidation: ConsolidationEngine,
+    config: EgoConfig | None = None,
 ) -> str:
     """Run memory consolidation."""
     stats = await consolidation.run(memory)
@@ -214,6 +219,18 @@ async def _handle_consolidate(
         _backfilled_count = _backfilled
     except Exception:
         pass
+
+    # Dead link detection (skip if workspace_dir is not configured)
+    dead_links: list[DeadLink] = []
+    if config is not None and config.workspace_dir is not None and notion_store is not None:
+        try:
+            dead_links = find_dead_links(notion_store, config.workspace_dir)
+        except Exception:
+            pass
+
+    dead_links_file_path = sum(1 for dl in dead_links if dl.link_type == "file_path")
+    dead_links_notion_ids = sum(1 for dl in dead_links if dl.link_type == "notion_ids")
+
     update_tool_metadata(
         consolidation_replay_events=stats.replay_events,
         consolidation_new_links=stats.link_updates,
@@ -246,6 +263,8 @@ async def _handle_consolidate(
         notion_merged=",".join(merged_notion_ids) if merged_notion_ids else None,
         notion_links_created=notion_links_created or None,
         person_backfilled=_backfilled_count or None,
+        dead_links_file_path=dead_links_file_path or None,
+        dead_links_notion_ids=dead_links_notion_ids or None,
     )
     base = (
         f"Consolidation complete. "
@@ -266,6 +285,14 @@ async def _handle_consolidate(
         base += f" Linked {notion_links_created} notion pair(s)."
     if _backfilled_count:
         base += f" Backfilled involved_person_ids for {_backfilled_count} memory(s)."
+    if dead_links:
+        dead_link_lines = []
+        for dl in dead_links:
+            targets = ", ".join(dl.dead_targets)
+            dead_link_lines.append(
+                f"  {dl.notion_id}.{dl.meta_key} ({dl.link_type}): {targets}"
+            )
+        base += f"\nDead links found ({len(dead_links)}):\n" + "\n".join(dead_link_lines)
     if not stats.merge_candidates:
         return base
 
@@ -403,11 +430,19 @@ def _handle_update_self(config: EgoConfig, args: dict[str, Any]) -> str:
     return f"Updated self.{field_name}"
 
 
-def _handle_curate_notions(args: dict[str, Any], notion_store: NotionStore) -> str:
+def _handle_curate_notions(
+    args: dict[str, Any],
+    notion_store: NotionStore,
+    config: EgoConfig | None = None,
+) -> str:
     def _compose(data: str) -> str:
         return compose_response(data, SCAFFOLD_CURATE_NOTIONS)
 
     action = str(args.get("action", "")).strip()
+
+    if action in ("add_meta", "update_meta", "remove_meta"):
+        return _handle_curate_notions_meta(action, args, notion_store, config)
+
     if action == "list":
         notions = sorted(
             notion_store.list_all(),
@@ -425,10 +460,15 @@ def _handle_curate_notions(args: dict[str, Any], notion_store: NotionStore) -> s
         for notion in notions[:15]:
             person_label = notion.person_id or "-"
             age = _call_relative_time(notion.created)
+            meta_parts = ", ".join(
+                f"{k}:{v['type']}" for k, v in notion.meta_fields.items()
+            )
+            meta_str = f" meta=[{meta_parts}]" if meta_parts else ""
             lines.append(
                 f'- {notion.id}: "{notion.label}" '
                 f"conf={notion.confidence:.2f} reinf={notion.reinforcement_count} "
                 f"age={age} person={person_label} related={len(notion.related_notion_ids)}"
+                f"{meta_str}"
             )
         return _compose("\n".join(lines))
 
@@ -471,6 +511,155 @@ def _handle_curate_notions(args: dict[str, Any], notion_store: NotionStore) -> s
         return _compose(f"Renamed {notion_id} to {new_label}")
 
     return _compose(f"Unknown action: {action}")
+
+
+def _handle_curate_notions_meta(
+    action: str,
+    args: dict[str, Any],
+    notion_store: NotionStore,
+    config: EgoConfig | None,
+) -> str:
+    """Handle add_meta, update_meta, remove_meta actions."""
+    def _compose(data: str) -> str:
+        return compose_response(data, SCAFFOLD_CURATE_NOTIONS)
+
+    notion_id = str(args.get("notion_id", "")).strip()
+    meta_key = str(args.get("meta_key", "")).strip()
+
+    if not notion_id:
+        return _compose("Error: notion_id is required.")
+    if not meta_key:
+        return _compose("Error: meta_key is required.")
+
+    notion = notion_store.get_by_id(notion_id)
+    if notion is None:
+        return _compose(f"Error: notion {notion_id} not found.")
+
+    if action == "add_meta":
+        meta_type = str(args.get("meta_type", "")).strip()
+        meta_value = args.get("meta_value")
+        if not meta_type:
+            return _compose("Error: meta_type is required for add_meta.")
+        if meta_value is None:
+            return _compose("Error: meta_value is required for add_meta.")
+
+        if meta_key in notion.meta_fields:
+            return _compose(f"Error: meta_field '{meta_key}' already exists. Use update_meta to modify.")
+
+        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config)
+        if isinstance(meta_field, str):
+            return _compose(meta_field)
+
+        notion.meta_fields[meta_key] = meta_field
+        notion_store.update(notion_id, meta_fields=notion.meta_fields)
+        update_tool_metadata(curate_action=action, curate_notion_id=notion_id)
+        return _compose(f"Added meta_field '{meta_key}' to notion {notion_id}.")
+
+    if action == "update_meta":
+        meta_value = args.get("meta_value")
+        if meta_value is None:
+            return _compose("Error: meta_value is required for update_meta.")
+
+        if meta_key not in notion.meta_fields:
+            return _compose(f"Error: meta_field '{meta_key}' does not exist. Use add_meta to create.")
+
+        existing = notion.meta_fields[meta_key]
+        meta_type = existing["type"]
+        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config)
+        if isinstance(meta_field, str):
+            return _compose(meta_field)
+
+        notion.meta_fields[meta_key] = meta_field
+        notion_store.update(notion_id, meta_fields=notion.meta_fields)
+        update_tool_metadata(curate_action=action, curate_notion_id=notion_id)
+        return _compose(f"Updated meta_field '{meta_key}' on notion {notion_id}.")
+
+    if action == "remove_meta":
+        if meta_key not in notion.meta_fields:
+            return _compose(f"Error: meta_field '{meta_key}' does not exist.")
+
+        del notion.meta_fields[meta_key]
+        notion_store.update(notion_id, meta_fields=notion.meta_fields)
+        update_tool_metadata(curate_action=action, curate_notion_id=notion_id)
+        return _compose(f"Removed meta_field '{meta_key}' from notion {notion_id}.")
+
+    return _compose(f"Error: unknown action: {action}")
+
+
+def _resolve_workspace_path(
+    workspace_dir: Path,
+    meta_value: str,
+) -> tuple[Path, str | None]:
+    """Resolve a file_path meta_value to a workspace-absolute path.
+
+    Returns (resolved_path, error_string).
+    On success error_string is None.
+    Rejects absolute paths and parent-traversal outside the workspace.
+    """
+    candidate = workspace_dir / meta_value
+    resolved = candidate.resolve()
+    workspace_resolved = workspace_dir.resolve()
+    try:
+        resolved.relative_to(workspace_resolved)
+    except ValueError:
+        return resolved, (
+            f"Error: file_path '{meta_value}' resolves outside the workspace. "
+            "Absolute paths and '..' escapes are not allowed."
+        )
+    return resolved, None
+
+
+def _validate_and_build_meta_field(
+    meta_type: str,
+    meta_value: Any,
+    notion_store: NotionStore,
+    config: EgoConfig | None,
+) -> MetaField | str:
+    """Validate meta_value based on type and build a MetaField dict.
+
+    Returns the MetaField on success, or an error string on failure.
+    """
+    if meta_type == "text":
+        if not isinstance(meta_value, str):
+            return "Error: meta_value must be a string for text type."
+        return {"type": "text", "value": meta_value}
+
+    if meta_type == "file_path":
+        if not isinstance(meta_value, str):
+            return "Error: meta_value must be a string (path) for file_path type."
+        if config is None or config.workspace_dir is None:
+            return (
+                "Error: EGO_MCP_WORKSPACE_DIR is not configured. "
+                "file_path meta_fields require a workspace directory."
+            )
+        resolved, err = _resolve_workspace_path(config.workspace_dir, meta_value)
+        if err is not None:
+            return err
+        if not meta_value or not resolved.is_file():
+            return f"Error: file not found: {meta_value}"
+        return {"type": "file_path", "path": meta_value}
+
+    if meta_type == "notion_ids":
+        if not isinstance(meta_value, list):
+            return (
+                "Error: meta_value must be an array of notion_ids "
+                "for notion_ids type."
+            )
+        validated_ids: list[str] = []
+        for item in meta_value:
+            if not isinstance(item, str) or not item.strip():
+                return (
+                    f"Error: each notion_ids entry must be a non-empty string, "
+                    f"got: {item!r}"
+                )
+            validated_ids.append(item.strip())
+        unique_ids = list(dict.fromkeys(validated_ids))
+        missing = [nid for nid in unique_ids if notion_store.get_by_id(nid) is None]
+        if missing:
+            return f"Error: notion(s) not found: {', '.join(missing)}"
+        return {"type": "notion_ids", "notion_ids": unique_ids}
+
+    return f"Error: unknown meta_type: {meta_type}"
 
 
 async def _handle_get_episode(

--- a/ego-mcp/src/ego_mcp/_server_backend_handlers.py
+++ b/ego-mcp/src/ego_mcp/_server_backend_handlers.py
@@ -546,7 +546,7 @@ def _handle_curate_notions_meta(
         if meta_key in notion.meta_fields:
             return _compose(f"Error: meta_field '{meta_key}' already exists. Use update_meta to modify.")
 
-        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config)
+        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config, owner_notion_id=notion_id)
         if isinstance(meta_field, str):
             return _compose(meta_field)
 
@@ -565,7 +565,7 @@ def _handle_curate_notions_meta(
 
         existing = notion.meta_fields[meta_key]
         meta_type = existing["type"]
-        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config)
+        meta_field = _validate_and_build_meta_field(meta_type, meta_value, notion_store, config, owner_notion_id=notion_id)
         if isinstance(meta_field, str):
             return _compose(meta_field)
 
@@ -614,6 +614,8 @@ def _validate_and_build_meta_field(
     meta_value: Any,
     notion_store: NotionStore,
     config: EgoConfig | None,
+    *,
+    owner_notion_id: str = "",
 ) -> MetaField | str:
     """Validate meta_value based on type and build a MetaField dict.
 
@@ -654,6 +656,8 @@ def _validate_and_build_meta_field(
                 )
             validated_ids.append(item.strip())
         unique_ids = list(dict.fromkeys(validated_ids))
+        if owner_notion_id and owner_notion_id in unique_ids:
+            return "Error: notion_ids must not reference the owning notion."
         missing = [nid for nid in unique_ids if notion_store.get_by_id(nid) is None]
         if missing:
             return f"Error: notion(s) not found: {', '.join(missing)}"

--- a/ego-mcp/src/ego_mcp/_server_surface_core.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_core.py
@@ -300,6 +300,17 @@ async def _handle_wake_up(
     )
     if ember_texts:
         parts.append("Embers:\n" + "\n".join(f"  {e}" for e in ember_texts))
+    if weakened_notions:
+        notion_lines = []
+        for wn in weakened_notions[:5]:
+            meta_parts = ", ".join(
+                f"{k}:{v['type']}" for k, v in wn.meta_fields.items()
+            )
+            meta_str = f" meta=[{meta_parts}]" if meta_parts else ""
+            notion_lines.append(
+                f'  "{wn.label}" conf={wn.confidence:.2f}{meta_str}'
+            )
+        parts.append("Weakened notions:\n" + "\n".join(notion_lines))
 
     # 3. Involuntary recall — Proust
     if recent_all:
@@ -431,9 +442,14 @@ async def _handle_introspect(
         if top_notions:
             framework_lines.append("Notion landscape:")
             for notion in top_notions:
+                meta_parts = ", ".join(
+                    f"{k}:{v['type']}" for k, v in notion.meta_fields.items()
+                )
+                meta_str = f" meta=[{meta_parts}]" if meta_parts else ""
                 framework_lines.append(
                     f'- "{notion.label}" confidence: {notion.confidence:.1f}'
                     f"{_format_associated_from_map(notion, notion_map, limit=2)}"
+                    f"{meta_str}"
                 )
 
     # §10.1 unresolved questions
@@ -654,8 +670,12 @@ async def _handle_consider_them(
     if person_notions:
         impression_lines = [f"Impressions of {person}:"]
         for notion in person_notions[:3]:
+            meta_parts = ", ".join(
+                f"{k}:{v['type']}" for k, v in notion.meta_fields.items()
+            )
+            meta_str = f" meta=[{meta_parts}]" if meta_parts else ""
             impression_lines.append(
-                f'  - "{notion.label}" confidence: {notion.confidence:.1f}'
+                f'  - "{notion.label}" confidence: {notion.confidence:.1f}{meta_str}'
             )
         data = f"{data}\n" + "\n".join(impression_lines)
     update_tool_metadata(
@@ -683,6 +703,10 @@ def _handle_pause() -> str:
     if convictions:
         lines = [data, "Your convictions:"]
         for notion in convictions[:5]:
-            lines.append(f'- "{notion.label}"')
+            meta_parts = ", ".join(
+                f"{k}:{v['type']}" for k, v in notion.meta_fields.items()
+            )
+            meta_str = f" meta=[{meta_parts}]" if meta_parts else ""
+            lines.append(f'- "{notion.label}"{meta_str}')
         data = "\n".join(lines)
     return compose_response(data, SCAFFOLD_PAUSE)

--- a/ego-mcp/src/ego_mcp/_server_surface_memory.py
+++ b/ego-mcp/src/ego_mcp/_server_surface_memory.py
@@ -494,6 +494,25 @@ async def _handle_recall(
                     f'"{notion.label}" {notion.emotion_tone.value} '
                     f"confidence: {notion.confidence:.1f}"
                 )
+                for mkey, mfield in notion.meta_fields.items():
+                    if not isinstance(mfield, dict):
+                        continue
+                    mtype = mfield.get("type", "")
+                    if mtype == "text":
+                        mval = mfield.get("value", "")
+                        if isinstance(mval, str) and len(mval) > 50:
+                            mval = mval[:47] + "..."
+                        lines.append(f"  [{mkey}] {mval}")
+                    elif mtype == "file_path":
+                        lines.append(f"  [{mkey}] -> {mfield.get('path', '')}")
+                    elif mtype == "notion_ids":
+                        mids = mfield.get("notion_ids", [])
+                        if isinstance(mids, list):
+                            display_ids = mids[:3]
+                            ids_str = ", ".join(str(x) for x in display_ids)
+                            if len(mids) > 3:
+                                ids_str += f" (+{len(mids) - 3})"
+                            lines.append(f"  [{mkey}] links: {ids_str}")
                 if associated:
                     lines.append(
                         "  → "

--- a/ego-mcp/src/ego_mcp/_server_tools.py
+++ b/ego-mcp/src/ego_mcp/_server_tools.py
@@ -247,13 +247,16 @@ BACKEND_TOOLS: list[Tool] = [
     ),
     Tool(
         name="curate_notions",
-        description="List, merge, relabel, or delete notions.",
+        description="Review and curate your notions: list, merge, relabel, delete, or manage meta_fields.",
         inputSchema={
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["list", "merge", "relabel", "delete"],
+                    "enum": [
+                        "list", "merge", "relabel", "delete",
+                        "add_meta", "update_meta", "remove_meta",
+                    ],
                 },
                 "notion_id": {"type": "string", "description": "Notion ID."},
                 "merge_into": {
@@ -267,6 +270,22 @@ BACKEND_TOOLS: list[Tool] = [
                 "person": {
                     "type": "string",
                     "description": "Associate person.",
+                },
+                "meta_key": {
+                    "type": "string",
+                    "description": "Key name for the meta_field.",
+                },
+                "meta_type": {
+                    "type": "string",
+                    "enum": ["text", "file_path", "notion_ids"],
+                    "description": "Type of meta_field.",
+                },
+                "meta_value": {
+                    "type": ["string", "array"],
+                    "description": (
+                        "Value for the meta_field. String for text/file_path, "
+                        "array of notion_ids for notion_ids type."
+                    ),
                 },
             },
             "required": ["action"],

--- a/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
+++ b/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
@@ -33,15 +33,21 @@ def up(data_dir: Path) -> None:
 
     updated_count = 0
 
-    # Handle legacy {"notions": [...]} format
+    # Handle legacy {"notions": [...]} format: convert to flat dict
     notions_list = data.get("notions")
     if isinstance(notions_list, list):
+        flat: dict[str, dict[str, object]] = {}
         for notion in notions_list:
             if not isinstance(notion, dict):
+                continue
+            notion_id = notion.get("id", "")
+            if not notion_id:
                 continue
             if "meta_fields" not in notion:
                 notion["meta_fields"] = {}
                 updated_count += 1
+            flat[str(notion_id)] = notion
+        data = flat
     else:
         # Handle current flat dict format keyed by notion ID
         for notion_id, notion in data.items():

--- a/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
+++ b/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
@@ -1,0 +1,64 @@
+"""Migration 0009: Add meta_fields to Notion.
+
+Adds empty meta_fields dict to all existing notions.
+Supports both the legacy {"notions": [...]} format and the
+current flat dict format keyed by notion ID.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+TARGET_VERSION = "1.2.0"
+
+
+def up(data_dir: Path) -> None:
+    """Add meta_fields to existing notions."""
+    notions_path = data_dir / "notions.json"
+
+    if not notions_path.exists():
+        return
+
+    try:
+        data = json.loads(notions_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+
+    if not isinstance(data, dict):
+        return
+
+    updated_count = 0
+
+    # Handle legacy {"notions": [...]} format
+    notions_list = data.get("notions")
+    if isinstance(notions_list, list):
+        for notion in notions_list:
+            if not isinstance(notion, dict):
+                continue
+            if "meta_fields" not in notion:
+                notion["meta_fields"] = {}
+                updated_count += 1
+    else:
+        # Handle current flat dict format keyed by notion ID
+        for notion_id, notion in data.items():
+            if not isinstance(notion, dict):
+                continue
+            if notion_id.startswith("_") or notion_id == "version":
+                continue
+            if "meta_fields" not in notion:
+                notion["meta_fields"] = {}
+                updated_count += 1
+
+    if updated_count == 0:
+        return
+
+    notions_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    logger.info("Migration 0009: added meta_fields to %d notion(s)", updated_count)

--- a/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
+++ b/ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py
@@ -32,10 +32,12 @@ def up(data_dir: Path) -> None:
         return
 
     updated_count = 0
+    was_legacy_list = False
 
     # Handle legacy {"notions": [...]} format: convert to flat dict
     notions_list = data.get("notions")
     if isinstance(notions_list, list):
+        was_legacy_list = True
         flat: dict[str, dict[str, object]] = {}
         for notion in notions_list:
             if not isinstance(notion, dict):
@@ -48,18 +50,19 @@ def up(data_dir: Path) -> None:
                 updated_count += 1
             flat[str(notion_id)] = notion
         data = flat
-    else:
-        # Handle current flat dict format keyed by notion ID
-        for notion_id, notion in data.items():
-            if not isinstance(notion, dict):
-                continue
-            if notion_id.startswith("_") or notion_id == "version":
-                continue
-            if "meta_fields" not in notion:
-                notion["meta_fields"] = {}
-                updated_count += 1
 
-    if updated_count == 0:
+    # Handle current flat dict format keyed by notion ID
+    for notion_id, notion in data.items():
+        if not isinstance(notion, dict):
+            continue
+        if notion_id.startswith("_") or notion_id == "version":
+            continue
+        if "meta_fields" not in notion:
+            notion["meta_fields"] = {}
+            updated_count += 1
+
+    needs_write = updated_count > 0 or was_legacy_list
+    if not needs_write:
         return
 
     notions_path.write_text(

--- a/ego-mcp/src/ego_mcp/notion.py
+++ b/ego-mcp/src/ego_mcp/notion.py
@@ -576,10 +576,12 @@ def merge_notions(
                     rewritten_meta[key] = mf
                     continue
                 new_ids = [
-                    keep.id if nid == absorb.id else nid
+                    (keep.id if nid == absorb.id else nid)
                     for nid in raw_ids
                     if nid
                 ]
+                if notion.id == keep.id:
+                    new_ids = [nid for nid in new_ids if nid != keep.id]
                 new_ids = list(dict.fromkeys(new_ids))
                 rewritten_meta[key] = {**mf, "notion_ids": new_ids}
             else:

--- a/ego-mcp/src/ego_mcp/notion.py
+++ b/ego-mcp/src/ego_mcp/notion.py
@@ -7,13 +7,13 @@ import math
 import re
 import uuid
 from collections import Counter, deque
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ego_mcp import timezone_utils
-from ego_mcp.types import Emotion, Memory, Notion
+from ego_mcp.types import Emotion, Memory, MetaField, Notion
 
 _PLACEHOLDER_NOTION_LABEL = re.compile(r"^untitled\s*\([^)]+\)$", re.IGNORECASE)
 _TITLE_SEPARATOR = re.compile(r"[.!?。！？\n]+")
@@ -159,6 +159,12 @@ class NotionStore:
 
     @staticmethod
     def _from_payload(payload: dict[str, Any]) -> Notion:
+        meta_fields_raw = payload.get("meta_fields", {})
+        meta_fields: dict[str, MetaField] = {}
+        if isinstance(meta_fields_raw, dict):
+            for key, value in meta_fields_raw.items():
+                if isinstance(value, dict) and "type" in value:
+                    meta_fields[key] = value  # type: ignore[assignment]
         return Notion(
             id=str(payload.get("id", "")),
             label=str(payload.get("label", "")),
@@ -172,6 +178,7 @@ class NotionStore:
             related_notion_ids=list(payload.get("related_notion_ids", [])),
             reinforcement_count=int(payload.get("reinforcement_count", 0)),
             person_id=str(payload.get("person_id", "")),
+            meta_fields=meta_fields,
         )
 
     def save(self, notion: Notion) -> None:
@@ -523,6 +530,11 @@ def merge_notions(
             if notion_id and notion_id not in {keep.id, absorb.id}
         )
     )
+    merged_meta_fields = dict(keep.meta_fields)
+    for key, value in absorb.meta_fields.items():
+        if key not in merged_meta_fields:
+            merged_meta_fields[key] = value
+
     merged = store.update(
         keep.id,
         source_memory_ids=list(
@@ -533,6 +545,7 @@ def merge_notions(
         confidence=max(keep.confidence, absorb.confidence),
         reinforcement_count=keep.reinforcement_count + absorb.reinforcement_count,
         person_id=merged_person_id,
+        meta_fields=merged_meta_fields,
     )
     if merged is None:
         return None
@@ -550,6 +563,30 @@ def merge_notions(
             )
         )
         store.update(notion.id, related_notion_ids=rewritten_related)
+
+    for notion in store.list_all():
+        rewritten_meta: dict[str, Any] = {}
+        for key, mf in notion.meta_fields.items():
+            if not isinstance(mf, dict):
+                rewritten_meta[key] = mf
+                continue
+            if mf.get("type") == "notion_ids":
+                raw_ids = mf.get("notion_ids", [])
+                if not isinstance(raw_ids, list):
+                    rewritten_meta[key] = mf
+                    continue
+                new_ids = [
+                    keep.id if nid == absorb.id else nid
+                    for nid in raw_ids
+                    if nid
+                ]
+                new_ids = list(dict.fromkeys(new_ids))
+                rewritten_meta[key] = {**mf, "notion_ids": new_ids}
+            else:
+                rewritten_meta[key] = mf
+        if rewritten_meta != notion.meta_fields:
+            store.update(notion.id, meta_fields=rewritten_meta)
+
     return store.get_by_id(keep.id)
 
 
@@ -675,3 +712,72 @@ def update_notion_from_memory(
         if updated is not None:
             results.append((notion.id, "weakened"))
     return results
+
+
+@dataclass
+class DeadLink:
+    """Represents a dead link in a meta_field."""
+
+    notion_id: str
+    meta_key: str
+    link_type: Literal["file_path", "notion_ids"]
+    dead_targets: list[str]
+
+
+def find_dead_links(
+    store: NotionStore,
+    workspace_dir: Path,
+) -> list[DeadLink]:
+    """Find dead links in meta_fields across all notions.
+
+    Checks:
+    - file_path: whether the referenced file exists
+    - notion_ids: whether each referenced notion exists
+
+    Returns list of DeadLink instances.
+    """
+    dead_links: list[DeadLink] = []
+
+    for notion in store.list_all():
+        for key, meta_field in notion.meta_fields.items():
+            if not isinstance(meta_field, dict):
+                continue
+            field_type = meta_field.get("type")
+
+            if field_type == "file_path":
+                path = meta_field.get("path", "")
+                if not isinstance(path, str):
+                    continue
+                full_path = workspace_dir / path
+                try:
+                    full_path.resolve().relative_to(workspace_dir.resolve())
+                except ValueError:
+                    dead_links.append(DeadLink(
+                        notion_id=notion.id,
+                        meta_key=key,
+                        link_type="file_path",
+                        dead_targets=[path],
+                    ))
+                    continue
+                if not full_path.is_file():
+                    dead_links.append(DeadLink(
+                        notion_id=notion.id,
+                        meta_key=key,
+                        link_type="file_path",
+                        dead_targets=[path],
+                    ))
+
+            elif field_type == "notion_ids":
+                notion_ids = meta_field.get("notion_ids", [])
+                if not isinstance(notion_ids, list):
+                    continue
+                missing = [nid for nid in notion_ids if store.get_by_id(nid) is None]
+                if missing:
+                    dead_links.append(DeadLink(
+                        notion_id=notion.id,
+                        meta_key=key,
+                        link_type="notion_ids",
+                        dead_targets=missing,
+                    ))
+
+    return dead_links

--- a/ego-mcp/src/ego_mcp/server.py
+++ b/ego-mcp/src/ego_mcp/server.py
@@ -189,9 +189,11 @@ def _handle_pause() -> str:
 
 
 async def _handle_consolidate(
-    memory: MemoryStore, consolidation: ConsolidationEngine
+    memory: MemoryStore,
+    consolidation: ConsolidationEngine,
+    config: EgoConfig | None = None,
 ) -> str:
-    return await _handlers._handle_consolidate(memory, consolidation)
+    return await _handlers._handle_consolidate(memory, consolidation, config)
 
 
 async def _handle_forget(memory: MemoryStore, args: dict[str, Any]) -> str:
@@ -210,8 +212,10 @@ def _handle_update_self(config: EgoConfig, args: dict[str, Any]) -> str:
     return _handlers._handle_update_self(config, args)
 
 
-def _handle_curate_notions(args: dict[str, Any], notion_store: NotionStore) -> str:
-    return _handlers._handle_curate_notions(args, notion_store)
+def _handle_curate_notions(
+    args: dict[str, Any], notion_store: NotionStore, config: EgoConfig | None
+) -> str:
+    return _handlers._handle_curate_notions(args, notion_store, config)
 
 
 def _handle_configure_desires(config: EgoConfig, args: dict[str, Any]) -> str:
@@ -477,7 +481,7 @@ async def _dispatch(
         return _handle_pause()
 
     elif name == "consolidate":
-        result = await _handle_consolidate(memory, consolidation)
+        result = await _handle_consolidate(memory, consolidation, config)
         _safe_satisfy_implicit("consolidate")
         return result
     elif name == "forget":
@@ -499,7 +503,7 @@ async def _dispatch(
     elif name == "create_episode":
         return await _handle_create_episode(episodes, args)
     elif name == "curate_notions":
-        result = _handle_curate_notions(args, _get_notion_store())
+        result = _handle_curate_notions(args, _get_notion_store(), config)
         _safe_satisfy_implicit("consolidate")
         return result
     else:

--- a/ego-mcp/src/ego_mcp/types.py
+++ b/ego-mcp/src/ego_mcp/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from ego_mcp import timezone_utils
 
@@ -146,6 +146,30 @@ class DesireState:
     created: str = ""
 
 
+class TextMetaField(TypedDict):
+    """Free-form text metadata."""
+
+    type: Literal["text"]
+    value: str
+
+
+class FilePathMetaField(TypedDict):
+    """Reference to a file in the workspace."""
+
+    type: Literal["file_path"]
+    path: str
+
+
+class NotionIdsMetaField(TypedDict):
+    """Reference to other notions."""
+
+    type: Literal["notion_ids"]
+    notion_ids: list[str]
+
+
+MetaField = TextMetaField | FilePathMetaField | NotionIdsMetaField
+
+
 @dataclass
 class Notion:
     """Abstracted concept distilled from memory clusters."""
@@ -162,6 +186,7 @@ class Notion:
     related_notion_ids: list[str] = field(default_factory=list)
     reinforcement_count: int = 0
     person_id: str = ""
+    meta_fields: dict[str, MetaField] = field(default_factory=dict)
 
 
 @dataclass

--- a/ego-mcp/tests/test_integration.py
+++ b/ego-mcp/tests/test_integration.py
@@ -2381,7 +2381,7 @@ class TestToolDefinitionSize:
         total_text = json.dumps([t.model_dump() for t in tools], ensure_ascii=False)
         total_chars = len(total_text)
         assert len(tools) == 16
-        # Target: 7,600 chars or less (increased from 7,500 to accommodate attune person field)
-        assert total_chars <= 7600, (
-            f"Tool definitions too large: {total_chars} chars (target: ≤7,600)"
+        # Target: 8,200 chars or less (increased to accommodate meta_fields in curate_notions)
+        assert total_chars <= 8200, (
+            f"Tool definitions too large: {total_chars} chars (target: ≤8,200)"
         )

--- a/ego-mcp/tests/test_notion.py
+++ b/ego-mcp/tests/test_notion.py
@@ -708,8 +708,8 @@ def test_merge_notions_rewrites_meta_fields_notion_ids(
     merged = merge_notions(store, "keep", "absorb")
 
     assert merged is not None
-    assert merged.meta_fields["ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
-    assert merged.meta_fields["self_ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
+    assert merged.meta_fields["ref"] == {"type": "notion_ids", "notion_ids": []}
+    assert merged.meta_fields["self_ref"] == {"type": "notion_ids", "notion_ids": []}
     other = store.get_by_id("other")
     assert other is not None
     assert other.meta_fields["points_to_absorb"] == {
@@ -752,7 +752,7 @@ def test_merge_notions_does_not_rewrite_unrelated_meta_fields(
     assert merged is not None
     assert merged.meta_fields["note"] == {"type": "text", "value": "hello"}
     assert merged.meta_fields["path_ref"] == {"type": "file_path", "path": "data.txt"}
-    assert merged.meta_fields["ids_ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
+    assert merged.meta_fields["ids_ref"] == {"type": "notion_ids", "notion_ids": []}
 
 
 def test_find_dead_links_reports_missing_file_path(tmp_path: Path) -> None:

--- a/ego-mcp/tests/test_notion.py
+++ b/ego-mcp/tests/test_notion.py
@@ -665,3 +665,190 @@ def test_infer_person_id_requires_majority_overlap() -> None:
         )
         == ""
     )
+
+
+def test_merge_notions_rewrites_meta_fields_notion_ids(
+    tmp_path: Path,
+) -> None:
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="keep",
+            label="Keep notion",
+            confidence=0.8,
+            reinforcement_count=2,
+            meta_fields={
+                "ref": {"type": "notion_ids", "notion_ids": ["absorb"]},
+            },
+        )
+    )
+    store.save(
+        Notion(
+            id="absorb",
+            label="Absorb notion",
+            confidence=0.7,
+            reinforcement_count=1,
+            meta_fields={
+                "self_ref": {"type": "notion_ids", "notion_ids": ["absorb"]},
+            },
+        )
+    )
+    store.save(
+        Notion(
+            id="other",
+            label="Other notion",
+            confidence=0.6,
+            reinforcement_count=1,
+            meta_fields={
+                "points_to_absorb": {"type": "notion_ids", "notion_ids": ["absorb", "keep"]},
+            },
+        )
+    )
+
+    merged = merge_notions(store, "keep", "absorb")
+
+    assert merged is not None
+    assert merged.meta_fields["ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
+    assert merged.meta_fields["self_ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
+    other = store.get_by_id("other")
+    assert other is not None
+    assert other.meta_fields["points_to_absorb"] == {
+        "type": "notion_ids",
+        "notion_ids": ["keep"],
+    }
+
+
+def test_merge_notions_does_not_rewrite_unrelated_meta_fields(
+    tmp_path: Path,
+) -> None:
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="keep",
+            label="Keep notion",
+            confidence=0.8,
+            reinforcement_count=2,
+            meta_fields={
+                "note": {"type": "text", "value": "hello"},
+                "path_ref": {"type": "file_path", "path": "data.txt"},
+                "ids_ref": {"type": "notion_ids", "notion_ids": ["keep"]},
+            },
+        )
+    )
+    store.save(
+        Notion(
+            id="absorb",
+            label="Absorb notion",
+            confidence=0.7,
+            reinforcement_count=1,
+            meta_fields={
+                "ids_ref": {"type": "notion_ids", "notion_ids": ["absorb"]},
+            },
+        )
+    )
+
+    merged = merge_notions(store, "keep", "absorb")
+
+    assert merged is not None
+    assert merged.meta_fields["note"] == {"type": "text", "value": "hello"}
+    assert merged.meta_fields["path_ref"] == {"type": "file_path", "path": "data.txt"}
+    assert merged.meta_fields["ids_ref"] == {"type": "notion_ids", "notion_ids": ["keep"]}
+
+
+def test_find_dead_links_reports_missing_file_path(tmp_path: Path) -> None:
+    from ego_mcp.notion import find_dead_links
+
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="n1",
+            label="notion with dead file",
+            confidence=0.5,
+            created="2026-01-01T00:00:00+00:00",
+            meta_fields={
+                "bad_file": {"type": "file_path", "path": "nonexistent.txt"},
+            },
+        )
+    )
+
+    dead = find_dead_links(store, tmp_path)
+
+    assert len(dead) == 1
+    assert dead[0].notion_id == "n1"
+    assert dead[0].meta_key == "bad_file"
+    assert dead[0].link_type == "file_path"
+    assert dead[0].dead_targets == ["nonexistent.txt"]
+
+
+def test_find_dead_links_reports_directory_as_dead_file_path(tmp_path: Path) -> None:
+    from ego_mcp.notion import find_dead_links
+
+    store = NotionStore(tmp_path / "notions.json")
+    sub_dir = tmp_path / "some_dir"
+    sub_dir.mkdir()
+    store.save(
+        Notion(
+            id="n1",
+            label="notion with dir reference",
+            confidence=0.5,
+            created="2026-01-01T00:00:00+00:00",
+            meta_fields={
+                "dir_ref": {"type": "file_path", "path": "some_dir"},
+            },
+        )
+    )
+
+    dead = find_dead_links(store, tmp_path)
+
+    assert len(dead) == 1
+    assert dead[0].notion_id == "n1"
+    assert dead[0].meta_key == "dir_ref"
+    assert dead[0].link_type == "file_path"
+
+
+def test_find_dead_links_reports_missing_notion_ids(tmp_path: Path) -> None:
+    from ego_mcp.notion import find_dead_links
+
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="n1",
+            label="notion with dead notion_ids",
+            confidence=0.5,
+            created="2026-01-01T00:00:00+00:00",
+            meta_fields={
+                "bad_ids": {"type": "notion_ids", "notion_ids": ["ghost_notion"]},
+            },
+        )
+    )
+
+    dead = find_dead_links(store, tmp_path)
+
+    assert len(dead) == 1
+    assert dead[0].notion_id == "n1"
+    assert dead[0].meta_key == "bad_ids"
+    assert dead[0].link_type == "notion_ids"
+    assert dead[0].dead_targets == ["ghost_notion"]
+
+
+def test_find_dead_links_healthy_meta_fields_not_reported(tmp_path: Path) -> None:
+    from ego_mcp.notion import find_dead_links
+
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="n1",
+            label="healthy notion",
+            confidence=0.5,
+            created="2026-01-01T00:00:00+00:00",
+            meta_fields={
+                "good_file": {"type": "file_path", "path": "exists.txt"},
+                "good_ids": {"type": "notion_ids", "notion_ids": ["n1"]},
+            },
+        )
+    )
+    (tmp_path / "exists.txt").write_text("hello")
+
+    dead = find_dead_links(store, tmp_path)
+
+    assert len(dead) == 0

--- a/ego-mcp/tests/test_notion_migration.py
+++ b/ego-mcp/tests/test_notion_migration.py
@@ -503,7 +503,7 @@ def test_0009_notion_meta_fields_handles_legacy_flat_dict_format(
     assert migrated.meta_fields == {}
 
 
-def test_0009_notion_meta_fields_handles_legacy_list_format(
+def test_0009_notion_meta_fields_converts_legacy_list_to_flat_dict(
     tmp_path: Path,
 ) -> None:
     migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
@@ -528,6 +528,41 @@ def test_0009_notion_meta_fields_handles_legacy_list_format(
     migration_mod.up(tmp_path)
 
     updated_data = json.loads(notions_file.read_text(encoding="utf-8"))
+    assert "notions" not in updated_data
+    assert "notion_list" in updated_data
+    assert updated_data["notion_list"]["meta_fields"] == {}
+
+    migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_list")
+    assert migrated is not None
+    assert migrated.label == "list notion"
+    assert migrated.meta_fields == {}
+
+
+def test_0009_notion_meta_fields_legacy_list_handles_missing_id(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    notions_file = tmp_path / "notions.json"
+    notions_file.write_text(
+        json.dumps({
+            "notions": [
+                {
+                    "label": "no id notion",
+                    "emotion_tone": "curious",
+                    "confidence": 0.5,
+                    "source_memory_ids": ["m1"],
+                    "created": "2026-03-01T00:00:00+00:00",
+                    "last_reinforced": "2026-03-01T00:00:00+00:00",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    migration_mod.up(tmp_path)
+
+    # Entry without id is skipped, so no write happens
+    updated_data = json.loads(notions_file.read_text(encoding="utf-8"))
     assert "notions" in updated_data
     assert len(updated_data["notions"]) == 1
-    assert updated_data["notions"][0]["meta_fields"] == {}
+    assert "meta_fields" not in updated_data["notions"][0]

--- a/ego-mcp/tests/test_notion_migration.py
+++ b/ego-mcp/tests/test_notion_migration.py
@@ -561,8 +561,45 @@ def test_0009_notion_meta_fields_legacy_list_handles_missing_id(
 
     migration_mod.up(tmp_path)
 
-    # Entry without id is skipped, so no write happens
+    # Legacy list with no valid IDs is converted to flat dict (empty)
     updated_data = json.loads(notions_file.read_text(encoding="utf-8"))
-    assert "notions" in updated_data
-    assert len(updated_data["notions"]) == 1
-    assert "meta_fields" not in updated_data["notions"][0]
+    assert "notions" not in updated_data
+    assert updated_data == {}
+
+
+def test_0009_notion_meta_fields_converts_legacy_list_even_when_all_have_meta_fields(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    notions_file = tmp_path / "notions.json"
+    notions_file.write_text(
+        json.dumps({
+            "notions": [
+                {
+                    "id": "notion_list",
+                    "label": "list notion",
+                    "emotion_tone": "curious",
+                    "confidence": 0.5,
+                    "source_memory_ids": ["m1"],
+                    "created": "2026-03-01T00:00:00+00:00",
+                    "last_reinforced": "2026-03-01T00:00:00+00:00",
+                    "meta_fields": {"note": {"type": "text", "value": "existing"}},
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    migration_mod.up(tmp_path)
+
+    updated_data = json.loads(notions_file.read_text(encoding="utf-8"))
+    assert "notions" not in updated_data
+    assert "notion_list" in updated_data
+    assert updated_data["notion_list"]["meta_fields"]["note"] == {
+        "type": "text",
+        "value": "existing",
+    }
+
+    migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_list")
+    assert migrated is not None
+    assert migrated.meta_fields["note"] == {"type": "text", "value": "existing"}

--- a/ego-mcp/tests/test_notion_migration.py
+++ b/ego-mcp/tests/test_notion_migration.py
@@ -424,3 +424,110 @@ def test_0004_notion_fields_keeps_reinforcement_count_zero_for_small_clusters(
     migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_small")
     assert migrated is not None
     assert migrated.reinforcement_count == 0
+
+
+def test_0009_notion_meta_fields_backfills_empty_dict_for_legacy_notions(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="notion_old",
+            label="old notion",
+            emotion_tone=Emotion.CURIOUS,
+            source_memory_ids=["m1", "m2", "m3"],
+            created="2026-03-01T00:00:00+00:00",
+            last_reinforced="2026-03-01T00:00:00+00:00",
+        )
+    )
+
+    migration_mod.up(tmp_path)
+
+    migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_old")
+    assert migrated is not None
+    assert migrated.meta_fields == {}
+
+
+def test_0009_notion_meta_fields_preserves_existing_meta_fields(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    store = NotionStore(tmp_path / "notions.json")
+    store.save(
+        Notion(
+            id="notion_with_meta",
+            label="notion with meta",
+            emotion_tone=Emotion.CURIOUS,
+            source_memory_ids=["m1", "m2", "m3"],
+            created="2026-03-01T00:00:00+00:00",
+            last_reinforced="2026-03-01T00:00:00+00:00",
+            meta_fields={
+                "note": {"type": "text", "value": "hello"},
+                "ids": {"type": "notion_ids", "notion_ids": ["other"]},
+            },
+        )
+    )
+
+    migration_mod.up(tmp_path)
+
+    migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_with_meta")
+    assert migrated is not None
+    assert migrated.meta_fields["note"] == {"type": "text", "value": "hello"}
+    assert migrated.meta_fields["ids"] == {"type": "notion_ids", "notion_ids": ["other"]}
+
+
+def test_0009_notion_meta_fields_handles_legacy_flat_dict_format(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    notions_file = tmp_path / "notions.json"
+    notions_file.write_text(
+        json.dumps({
+            "notion_legacy": {
+                "label": "legacy notion",
+                "emotion_tone": "curious",
+                "confidence": 0.5,
+                "source_memory_ids": ["m1"],
+                "created": "2026-03-01T00:00:00+00:00",
+                "last_reinforced": "2026-03-01T00:00:00+00:00",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    migration_mod.up(tmp_path)
+
+    migrated = NotionStore(tmp_path / "notions.json").get_by_id("notion_legacy")
+    assert migrated is not None
+    assert migrated.meta_fields == {}
+
+
+def test_0009_notion_meta_fields_handles_legacy_list_format(
+    tmp_path: Path,
+) -> None:
+    migration_mod = importlib.import_module("ego_mcp.migrations.0009_notion_meta_fields")
+    notions_file = tmp_path / "notions.json"
+    notions_file.write_text(
+        json.dumps({
+            "notions": [
+                {
+                    "id": "notion_list",
+                    "label": "list notion",
+                    "emotion_tone": "curious",
+                    "confidence": 0.5,
+                    "source_memory_ids": ["m1"],
+                    "created": "2026-03-01T00:00:00+00:00",
+                    "last_reinforced": "2026-03-01T00:00:00+00:00",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    migration_mod.up(tmp_path)
+
+    updated_data = json.loads(notions_file.read_text(encoding="utf-8"))
+    assert "notions" in updated_data
+    assert len(updated_data["notions"]) == 1
+    assert updated_data["notions"][0]["meta_fields"] == {}

--- a/ego-mcp/tests/test_server.py
+++ b/ego-mcp/tests/test_server.py
@@ -1494,11 +1494,12 @@ class TestForgetToolServerHandlers:
             "_call_relative_time",
             lambda _timestamp, now=None: "2d ago",
         )
-        text = server_mod._handle_curate_notions({"action": "list"}, store)
+        text = server_mod._handle_curate_notions({"action": "list"}, store, None)
         assert get_tool_metadata()["curate_action"] == "list"
         deleted = server_mod._handle_curate_notions(
             {"action": "delete", "notion_id": "notion_1"},
             store,
+            None,
         )
 
         assert "Pattern seeking" in text
@@ -1534,10 +1535,12 @@ class TestForgetToolServerHandlers:
         merged = server_mod._handle_curate_notions(
             {"action": "merge", "notion_id": "absorb", "merge_into": "keep", "person": "Master"},
             store,
+            None,
         )
         relabeled = server_mod._handle_curate_notions(
             {"action": "relabel", "notion_id": "keep", "new_label": "Merged pattern", "person": ""},
             store,
+            None,
         )
         notion = store.get_by_id("keep")
 
@@ -1550,24 +1553,474 @@ class TestForgetToolServerHandlers:
     def test_handle_curate_notions_error_paths(self, tmp_path: Path) -> None:
         store = NotionStore(tmp_path / "notions.json")
 
-        missing_id = server_mod._handle_curate_notions({"action": "delete"}, store)
+        missing_id = server_mod._handle_curate_notions({"action": "delete"}, store, None)
         missing_merge_into = server_mod._handle_curate_notions(
             {"action": "merge", "notion_id": "missing"},
             store,
+            None,
         )
         missing_new_label = server_mod._handle_curate_notions(
             {"action": "relabel", "notion_id": "missing"},
             store,
+            None,
         )
         missing_target = server_mod._handle_curate_notions(
             {"action": "delete", "notion_id": "missing"},
             store,
+            None,
         )
 
         assert "notion_id is required." in missing_id
         assert "merge_into is required for merge." in missing_merge_into
         assert "new_label is required for relabel." in missing_new_label
         assert "Notion not found: missing" in missing_target
+
+    def test_handle_curate_notions_add_meta_success(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        (workspace_dir / "file.txt").write_text("content")
+        config = EgoConfig(
+            embedding_provider="gemini",
+            embedding_model="gemini-embedding-001",
+            api_key="test-key",
+            data_dir=tmp_path,
+            companion_name="Master",
+            workspace_dir=workspace_dir,
+            timezone="UTC",
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "note",
+                "meta_type": "text",
+                "meta_value": "hello",
+            },
+            store,
+            config,
+        )
+
+        assert "Added meta_field 'note'" in result
+        assert get_tool_metadata()["curate_action"] == "add_meta"
+        assert get_tool_metadata()["curate_notion_id"] == "n1"
+        notion = store.get_by_id("n1")
+        assert notion is not None
+        assert notion.meta_fields["note"] == {"type": "text", "value": "hello"}
+
+    def test_handle_curate_notions_add_meta_rejects_duplicate_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+                meta_fields={
+                    "existing": {"type": "text", "value": "old"},
+                },
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "existing",
+                "meta_type": "text",
+                "meta_value": "new",
+            },
+            store,
+            None,
+        )
+
+        assert "already exists" in result
+
+    def test_handle_curate_notions_add_meta_rejects_directory_as_file_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        (workspace_dir / "subdir").mkdir()
+        config = EgoConfig(
+            embedding_provider="gemini",
+            embedding_model="gemini-embedding-001",
+            api_key="test-key",
+            data_dir=tmp_path,
+            companion_name="Master",
+            workspace_dir=workspace_dir,
+            timezone="UTC",
+        )
+
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "dir_ref",
+                "meta_type": "file_path",
+                "meta_value": "subdir",
+            },
+            store,
+            config,
+        )
+
+        assert "file not found" in result
+
+    def test_handle_curate_notions_add_meta_rejects_empty_file_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        config = EgoConfig(
+                embedding_provider="gemini",
+                embedding_model="gemini-embedding-001",
+                api_key="test-key",
+                data_dir=tmp_path,
+                companion_name="Master",
+                workspace_dir=workspace_dir,
+                timezone="UTC",
+            )
+
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "empty_ref",
+                "meta_type": "file_path",
+                "meta_value": "",
+            },
+            store,
+            config,
+        )
+
+        assert "file not found" in result
+
+    def test_handle_curate_notions_add_meta_rejects_dot_file_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        config = EgoConfig(
+                embedding_provider="gemini",
+                embedding_model="gemini-embedding-001",
+                api_key="test-key",
+                data_dir=tmp_path,
+                companion_name="Master",
+                workspace_dir=workspace_dir,
+                timezone="UTC",
+            )
+
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "dot_ref",
+                "meta_type": "file_path",
+                "meta_value": ".",
+            },
+            store,
+            config,
+        )
+
+        assert "file not found" in result
+
+    def test_handle_curate_notions_add_meta_rejects_absolute_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        config = EgoConfig(
+                embedding_provider="gemini",
+                embedding_model="gemini-embedding-001",
+                api_key="test-key",
+                data_dir=tmp_path,
+                companion_name="Master",
+                workspace_dir=workspace_dir,
+                timezone="UTC",
+            )
+
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "abs_ref",
+                "meta_type": "file_path",
+                "meta_value": "/etc/hosts",
+            },
+            store,
+            config,
+        )
+
+        assert "resolves outside the workspace" in result
+
+    def test_handle_curate_notions_update_meta_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+                meta_fields={
+                    "note": {"type": "text", "value": "old value"},
+                },
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "update_meta",
+                "notion_id": "n1",
+                "meta_key": "note",
+                "meta_type": "text",
+                "meta_value": "new value",
+            },
+            store,
+            None,
+        )
+
+        assert "Updated meta_field 'note'" in result
+        assert get_tool_metadata()["curate_action"] == "update_meta"
+        notion = store.get_by_id("n1")
+        assert notion is not None
+        assert notion.meta_fields["note"] == {"type": "text", "value": "new value"}
+
+    def test_handle_curate_notions_update_meta_rejects_nonexistent_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+                meta_fields={},
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "update_meta",
+                "notion_id": "n1",
+                "meta_key": "missing",
+                "meta_type": "text",
+                "meta_value": "value",
+            },
+            store,
+            None,
+        )
+
+        assert "does not exist" in result
+
+    def test_handle_curate_notions_remove_meta_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+                meta_fields={
+                    "note": {"type": "text", "value": "hello"},
+                },
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "remove_meta",
+                "notion_id": "n1",
+                "meta_key": "note",
+            },
+            store,
+            None,
+        )
+
+        assert "Removed meta_field 'note'" in result
+        assert get_tool_metadata()["curate_action"] == "remove_meta"
+        notion = store.get_by_id("n1")
+        assert notion is not None
+        assert notion.meta_fields == {}
+
+    def test_handle_curate_notions_add_meta_rejects_malformed_notion_ids(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "bad_ids",
+                "meta_type": "notion_ids",
+                "meta_value": [123],
+            },
+            store,
+            None,
+        )
+
+        assert "must be a non-empty string" in result
+
+        result2 = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "bad_ids2",
+                "meta_type": "notion_ids",
+                "meta_value": ["valid", "", "also_valid"],
+            },
+            store,
+            None,
+        )
+
+        assert "must be a non-empty string" in result2
+
+    def test_handle_curate_notions_add_meta_with_notion_ids_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion 1",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+        store.save(
+            Notion(
+                id="n2",
+                label="Test notion 2",
+                confidence=0.7,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "linked",
+                "meta_type": "notion_ids",
+                "meta_value": ["n2", "n2", "n1"],
+            },
+            store,
+            None,
+        )
+
+        assert "Added meta_field 'linked'" in result
+        notion = store.get_by_id("n1")
+        assert notion is not None
+        assert notion.meta_fields["linked"] == {
+            "type": "notion_ids",
+            "notion_ids": ["n2", "n1"],
+        }
+
+    def test_handle_curate_notions_add_meta_rejects_missing_notion_ids(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "ghost",
+                "meta_type": "notion_ids",
+                "meta_value": ["ghost_notion"],
+            },
+            store,
+            None,
+        )
+
+        assert "notion(s) not found" in result
 
     @pytest.mark.asyncio
     async def test_handle_get_episode_filters_deleted_memory_ids_and_adds_note(self) -> None:

--- a/ego-mcp/tests/test_server.py
+++ b/ego-mcp/tests/test_server.py
@@ -1980,7 +1980,7 @@ class TestForgetToolServerHandlers:
                 "notion_id": "n1",
                 "meta_key": "linked",
                 "meta_type": "notion_ids",
-                "meta_value": ["n2", "n2", "n1"],
+                "meta_value": ["n2", "n2"],
             },
             store,
             None,
@@ -1991,8 +1991,63 @@ class TestForgetToolServerHandlers:
         assert notion is not None
         assert notion.meta_fields["linked"] == {
             "type": "notion_ids",
-            "notion_ids": ["n2", "n1"],
+            "notion_ids": ["n2"],
         }
+
+    def test_handle_curate_notions_add_meta_rejects_self_referential_notion_ids(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = NotionStore(tmp_path / "notions.json")
+        store.save(
+            Notion(
+                id="n1",
+                label="Test notion",
+                confidence=0.8,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+        store.save(
+            Notion(
+                id="n2",
+                label="Test notion 2",
+                confidence=0.7,
+                created="2026-02-24T00:00:00+00:00",
+            )
+        )
+
+        result = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "self_ref",
+                "meta_type": "notion_ids",
+                "meta_value": ["n1"],
+            },
+            store,
+            None,
+        )
+
+        assert "must not reference the owning notion" in result
+
+        result2 = server_mod._handle_curate_notions(
+            {
+                "action": "add_meta",
+                "notion_id": "n1",
+                "meta_key": "mixed_ref",
+                "meta_type": "notion_ids",
+                "meta_value": ["n2", "n1"],
+            },
+            store,
+            None,
+        )
+
+        assert "must not reference the owning notion" in result2
+
+        notion = store.get_by_id("n1")
+        assert notion is not None
+        assert "self_ref" not in notion.meta_fields
+        assert "mixed_ref" not in notion.meta_fields
 
     def test_handle_curate_notions_add_meta_rejects_missing_notion_ids(
         self,

--- a/ego-mcp/uv.lock
+++ b/ego-mcp/uv.lock
@@ -357,7 +357,7 @@ wheels = [
 
 [[package]]
 name = "ego-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- **P1**: Migration 0009 now always converts legacy `{"notions": [...]}` format to flat dict, even when all notions already have `meta_fields`
- **P2**: `merge_notions()` no longer creates self-referential `notion_ids` — surviving notion's own ID is dropped from arrays after rewriting absorbed IDs

## Changes

### `ego-mcp/src/ego_mcp/migrations/0009_notion_meta_fields.py`
- Track `was_legacy_list` flag separately from `updated_count`
- Always write when input was legacy list format, regardless of whether backfill was needed

### `ego-mcp/src/ego_mcp/notion.py`
- In `merge_notions()`, after rewriting absorbed notion IDs to the surviving ID, filter out self-references (owner's own ID from `notion_ids` arrays)

### Tests
- `test_0009_notion_meta_fields_converts_legacy_list_even_when_all_have_meta_fields` — verifies migration converts legacy list even when no backfill needed
- `test_0009_notion_meta_fields_legacy_list_handles_missing_id` — verifies empty legacy list becomes empty flat dict
- `test_merge_notions_rewrites_meta_fields_notion_ids` — updated to assert self-references are removed
- `test_merge_notions_does_not_rewrite_unrelated_meta_fields` — updated to assert self-references are removed

## CI

All checks pass:
- ego-mcp: 887 passed, isort/ruff/mypy clean
- dashboard backend: 127 passed, ruff/mypy/format clean
- dashboard frontend: 116 tests passed, lint/format/build clean